### PR TITLE
Make hackathon sponsor onboarding and contextual demos runnable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,20 +3,30 @@
 #
 #   cp .env.example .env      then fill in TIER 0 and you can already run.
 #
-# Every variable below says where to click to get it. The `stub-replace-me`
-# placeholder lets the process boot before you have real credentials — chat
-# will fail with an auth error until you swap it for a real key.
+# Replace the selected provider's placeholder with your own key. Preflight
+# checks only that provider; optional sponsors can be added when needed.
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 # ── TIER 0 · one credential, no provider app, no Docker ──────────────────────
-# Get a key: https://platform.openai.com/api-keys  (starts with sk-)
+# Choose one chat provider explicitly: openai or openrouter.
+# OpenAI: https://platform.openai.com/api-keys
+MODEL_PROVIDER=openai
 OPENAI_API_KEY=stub-replace-me
-
-# Chat model. Defaults to the flagship. gpt-6-astra is the step up for hard
-# end-to-end work; gpt-5.6-luna is ~25x cheaper if you are burning credits.
-# See dev-docs/model-switching.md before changing this.
 MODEL=gpt-5.6-sol
+
+# To use OpenRouter instead, change MODEL_PROVIDER=openrouter, set its key,
+# and choose a model from https://openrouter.ai/models (publisher/model).
+# No OpenAI key is required for OpenRouter chat.
+# Get a key: https://openrouter.ai/keys
+# OPENROUTER_API_KEY=
+# MODEL=openai/gpt-5.6-sol
+# With MODEL_PROVIDER unset, an OpenRouter key selects OpenRouter; otherwise
+# a MODEL provider prefix selects that provider, defaulting to OpenAI.
+# Existing anthropic/ and google/ model prefixes remain supported with their
+# ANTHROPIC_API_KEY and GOOGLE_API_KEY respectively. See dev-docs/model-switching.md.
+# Browser voice always needs OPENAI_API_KEY for Realtime, independently of chat.
+# Check voice setup with: npm run check-env -- --voice
 
 
 # ── TIER 1 · put the agent in Slack (or Teams). Zero tunnel required. ────────
@@ -67,11 +77,6 @@ EXA_API_KEY=
 # choices inside a chat thread. `deep-reasoning` takes up to 40s and reads as
 # broken in Slack.
 EXA_SEARCH_TYPE=fast
-
-# OpenRouter — live-demo insurance. If OpenAI rate-limits you at 14:00, this is
-# how you keep the day. See dev-docs/model-switching.md.
-# Get a key: https://openrouter.ai/keys
-# OPENROUTER_API_KEY=
 
 # Ambiguous AI — a 17-app workplace (mail, tasks, CRM, docs, calendar) the agent
 # can actually act in, over MCP. Set this and the agent gains those tools and is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: Verify starter kit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  starter-kit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run verify
+      - run: npm run build --workspace web
+
+  auth0-example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: examples/auth0/package-lock.json
+      - run: npm ci --prefix examples/auth0
+      - run: npm test --prefix examples/auth0
+
+  mozilla-example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: examples/mozilla/requirements.txt
+      - run: python -m pip install -r examples/mozilla/requirements.txt
+      - run: python -m pip check
+      - run: python -m unittest discover -s examples/mozilla -v

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,19 +1,20 @@
 # Sponsor credits and offers
 
-**Fill this in at the 10:30 opening session.** Builder credits, promo codes, and
-per-sponsor offers were not published before the event, so nothing here is
-pre-filled — inventing them would be worse than leaving them blank.
+Record the offers and redemption instructions provided by event organizers.
+Do not assume a public plan or account signup includes hackathon credits. Check
+[the San Francisco event page](https://sf.aitinkerers.org/p/agents-everywhere-bots-channels-more-global-hackathon)
+and the opening-session announcements; local offers may differ.
 
-| Sponsor | What to claim | Code / link | Claimed |
+| Sponsor | Build with it | Organizer offer / redemption link | Claimed |
 |---|---|---|---|
-| OpenAI | | | ☐ |
-| CopilotKit | Intelligence free tier | <https://copilotkit.ai> | ☐ |
-| OpenRouter | | <https://openrouter.ai/keys> | ☐ |
-| Exa | free plan covers casual use | <https://dashboard.exa.ai/api-keys> | ☐ |
-| Trigger.dev | | <https://trigger.dev> | ☐ |
-| Auth0 | | <https://auth0.com/ai> | ☐ |
-| Mozilla.ai | all open source | <https://github.com/mozilla-ai> | ☐ |
-| Ambiguous AI | free for teams of 5, 1,000 actions/mo | `npx ambiguous auth signup` | ☐ |
+| OpenAI | [Incident reasoning](dev-docs/sponsors.md#openai) | | ☐ |
+| CopilotKit | [Context and native UI](dev-docs/sponsors.md#copilotkit) | | ☐ |
+| OpenRouter | [Model choice](dev-docs/sponsors.md#openrouter) | | ☐ |
+| Exa | [Grounded search](dev-docs/sponsors.md#exa) | | ☐ |
+| Trigger.dev | [Durable research](dev-docs/sponsors.md#triggerdev) | | ☐ |
+| Auth0 | [Protected action](dev-docs/sponsors.md#auth0) | | ☐ |
+| Mozilla.ai | [Agent trace](dev-docs/sponsors.md#mozillaai) | | ☐ |
+| Ambiguous AI | [Workplace follow-up](dev-docs/sponsors.md#ambiguous-ai) | | ☐ |
 
-Local rosters differ by city — Veris AI hosts the NYC venue, Google Cloud Run
-appears on the Toronto page. Check your own city's event page.
+Use only the tools your idea needs. See [sponsor recipes](dev-docs/sponsors.md) for
+configuration and result checks; record actual usage in your submission.

--- a/README.md
+++ b/README.md
@@ -4,390 +4,114 @@
 
 ![Agents, everywhere — build an agent that belongs where people already work](assets/banner.png)
 
-Slack and Teams out of the box, one agent behind every surface, and no tunnel.
+Build an agent that belongs where people already work, talk, and live.
 
-[Quickstart](#run-it-locally) · [The Context Ladder](#the-context-ladder) · [Stack](#stack) · [dev-docs](dev-docs/) · [Submission checklist](SUBMISSION.md)
+[Quickstart](#run-it-locally) · [Choose a surface](#choose-a-surface) · [Sponsor recipes](dev-docs/sponsors.md) · [Demo](dev-docs/demo-prompts.md) · [Submission](SUBMISSION.md)
 
 </div>
 
----
+Built for **[Agents, Everywhere: Bots, Channels, & More](https://sf.aitinkerers.org/p/agents-everywhere-bots-channels-more-global-hackathon)**, the AI Tinkerers global hackathon on **September 12, 2026**. Start with a working example, connect the sponsor tools your idea needs, and make the surrounding context useful. You do not need every sponsor or every surface.
 
-## About this starter
+## The demo you can build on
 
-Built for **[Agents, Everywhere: Bots, Channels, & More](https://aitinkerers.org/hackathons/global/agents-everywhere)** — the AI Tinkerers global hackathon with OpenAI, Saturday 12 September 2026, 51 cities, one global submission pool.
+An on-call assistant reads an existing incident thread, researches public sources, and presents a native incident card. Add an Ambiguous AI workspace to create a real follow-up and return its record link to the thread. Or use Trigger.dev to queue approved research and retrieve its sources in that same conversation.
 
-The build window is **11:15–15:30**. That is **255 minutes**, and every decision in this kit follows from it:
+Prefer a browser demo? The included incident workspace gives the agent the selected incident and timeline. Ask it to switch incidents or add a follow-up, then watch the page change. These are sample incidents and session-only tasks; refreshing resets them.
 
-- **One credential gets you a running agent.** No Docker, no Postgres, no second process.
-- **Zero tunnel for Slack.** No ngrok, no public URL of your own, no app-level token.
-- **Six surfaces, so you can pick one.** Terminal, Slack, web, voice, ChatGPT and mobile all run the *same* agent. Take one and go deep — see [Pick one surface](#pick-one-surface).
-- **A pre-flight check that fails loudly**, with a numbered list of exactly what to fix.
-
-Everything here is meant to be gutted. Keep the plumbing, throw away the demo.
-
----
-
-## The Context Ladder
-
-The challenge is not "build a bot." It is: *make it meaningfully more useful **because of that context**.* That is a ladder, and it climbs.
-
-|   | Level | The agent… | The test |
-|---|---|---|---|
-| **1** | **Reachable** | is addressable where you already are — mention it, it answers | Table stakes. Every submission in every city clears this. |
-| **2** | **Situated** | reads the surface's context without being told — thread history, the doc you're in, who's asking, what happened an hour ago | Delete the context and ask again. Same answer? You're still on rung 1. |
-| **3** | **Native** | acts and renders in the surface's own idioms — Block Kit cards, approval buttons, reactions, notifications — and its side effects land where the work lives | Does it look like it belongs, or like a chat window wearing a costume? |
-
-Rung 3 is where a global review separates submissions. This kit ships working code for all three: `read_thread` for rung 2, `brief_card` / `comparison_table` for rung 3, and `confirm_action` for the approval gate that makes an agent trustworthy enough to leave in a channel.
-
----
-
-## Pick one surface
-
-The event is explicit: **"a sharp, working demo beats a broad concept."** This kit
-ships six surfaces so you can choose the one your idea actually belongs in — not
-so you can build all six. A team that demos six half-finished surfaces loses to a
-team that demos one that genuinely belongs somewhere.
-
-So: **pick one, go deep, and use a second only as the closing beat of your video.**
-
-| If your idea lives… | Start here | Why this one |
-|---|---|---|
-| where a team argues about something | `apps/channel-slack` | The thread is already the record. Highest ceiling, lowest setup — no tunnel. |
-| in a tool someone stares at all day | `apps/web` | Generative UI: the agent operates the app, not just talks about it. |
-| in a room, hands busy | `apps/web/voice` | Realtime over WebRTC. The only surface where latency *is* the product. |
-| inside ChatGPT itself | `apps/mcp` | Distribution you don't have to build. Verified against the live protocol. |
-| in a pocket, between things | `apps/mobile` | Notifications and one-tap approvals beat another chat app. |
-
-Two honest cautions before you choose:
-
-- **`apps/mobile` is the least proven** — it installs and typechecks, but nobody
-  has run it on a device. Don't pick it at 11:15 and discover that at 15:00.
-- **Voice punishes slow tools.** If your agent needs `deep` research, it will feel
-  broken out loud. Exa's `instant` profile exists for this.
-
-The other surfaces still boot, so a second one is nearly free — that is what makes
-"and it also works on my phone" a ten-second closing shot rather than a second
-project.
-
----
+Follow the exact prompts and result checks in [the demo walkthrough](dev-docs/demo-prompts.md). Approval cards alone do not execute a restart or create a task.
 
 ## Run it locally
 
-### Tier 0 — one credential, ~5 minutes
+Requires **Node.js 22+** (`nvm use`) and one model-provider account.
 
 ```bash
+git clone https://github.com/CopilotKit/agents-everywhere-starter-kit.git
+cd agents-everywhere-starter-kit
 npm install
-cp .env.example .env      # paste an OPENAI_API_KEY
+cp .env.example .env
+```
+
+Edit `.env` with **one** of these choices:
+
+| | OpenAI | OpenRouter |
+|---|---|---|
+| `MODEL_PROVIDER` | `openai` | `openrouter` |
+| Credential | `OPENAI_API_KEY` | `OPENROUTER_API_KEY` |
+| `MODEL` | `gpt-5.6-sol` | `openai/gpt-5.6-sol` or an available publisher/model slug |
+| Get access | [API keys](https://platform.openai.com/api-keys) | [API keys](https://openrouter.ai/keys) · [model catalog](https://openrouter.ai/models) |
+
+Replace the selected provider's placeholder with your key. OpenRouter chat needs no OpenAI key. Explicit selection takes precedence over other saved keys; see [model switching](dev-docs/model-switching.md).
+
+```bash
 npm run dev
 ```
 
-With no Channel configured yet, `npm run dev` starts the **terminal surface** — the same agent, sub-second loop, no Slack round trip. Use it to tune the prompt before you wire anything up.
+With no Channel configured, this starts terminal chat. Try: “Here is an incident: checkout timeouts began after a deploy, rollback did not help, payment queue depth is rising. What should we investigate?” Terminal chat exercises the model and prompt; it has no Slack history or native cards.
 
-> `npm run dev` runs a pre-flight check first. It fails with a numbered list of missing keys, a malformed Channel Code, or a Node version too old for Channels. Fix what it lists and re-run. `npm run check-env` any time.
-
-### Tier 1 — the agent lives in Slack, ~15 minutes
+To open the incident workspace instead:
 
 ```bash
-npm run channel:setup
+npm run dev:web
 ```
 
-That installs a skill, prints a prompt, and copies it to your clipboard — paste it into Claude Code or Cursor and it drives the Slack and Intelligence consoles in your own signed-in session. You type the secrets; it does the clicking.
+Open the localhost URL printed by Next.js. For Slack, run `npm run channel:setup`, configure `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`, then run `npm run dev` and mention the invited bot. The managed listener needs no public tunnel. [Full setup](dev-docs/setup.md)
 
-By hand, in this order (**the order matters** — the Channel wizard generates the Slack app manifest, so creating the app first means creating the wrong app):
+## Choose a surface
 
-```bash
-npx copilotkit@latest channels add --name my-agent \
-  --display-name "My Agent" --adapter slack --json
-```
+| Where your idea belongs | Start with | What the example supplies |
+|---|---|---|
+| Team conversations | `apps/channel-slack` | Thread history, incident cards, approvals, optional search and durable research |
+| An application | `apps/web` | Incident context, timeline, visible local actions, native cards |
+| A quick prompt experiment | `apps/local-chat` | Terminal conversation with your chosen chat provider |
+| A spoken conversation | `apps/web` at `/voice` | Separate OpenAI Realtime agent; requires an OpenAI key and microphone |
+| An MCP client | `apps/mcp` | Tools and a UI resource; the host supplies the model |
+| A mobile application | `apps/mobile` | Separate Expo scaffold; not device-verified |
 
-Then put the Channel **Code** in `CHANNEL_CODE`, a project-scoped key in `INTELLIGENCE_API_KEY`, and run `npm run dev` again. In Slack: `/invite @yourbot`, then @-mention it.
+Capabilities differ by surface. Read [the capability matrix and launch commands](dev-docs/surfaces.md) before choosing a second one. Teams uses the Channels adapter path and requires its own setup and validation.
 
-Full walkthrough: **[dev-docs/setup.md](dev-docs/setup.md)**. Stuck: **[dev-docs/troubleshooting.md](dev-docs/troubleshooting.md)**.
+## Choose the sponsors your demo needs
 
-### Verify it
+Each [sponsor recipe](dev-docs/sponsors.md) includes access, configuration, commands, expected output, and a file to customize.
+
+| Sponsor | A useful first result | Recipe |
+|---|---|---|
+| OpenAI | Reason about supplied incident context | [Chat provider](dev-docs/sponsors.md#openai) |
+| CopilotKit | Read a thread or operate the incident workspace | [Context and native UI](dev-docs/sponsors.md#copilotkit) |
+| OpenRouter | Run the same scenario with your selected model | [Model choice](dev-docs/sponsors.md#openrouter) |
+| Exa | Research with visible source links | [Grounded search](dev-docs/sponsors.md#exa) |
+| Trigger.dev | Approve research, keep chatting, retrieve the result | [Durable research](dev-docs/sponsors.md#triggerdev) |
+| Auth0 | Deny an unauthenticated action, authorize a service, create a local record | [Runnable M2M example](examples/auth0/README.md) |
+| Mozilla.ai | Run an incident tool and save an inspectable agent trace | [Runnable Python example](examples/mozilla/README.md) |
+| Ambiguous AI | Create a real workspace follow-up and return its link | [Workplace actions](dev-docs/sponsors.md#ambiguous-ai) |
+
+Auth0 and Mozilla are independent examples. Auth0 demonstrates machine authorization; the separate CIBA consent extension is still unimplemented. Live sponsor calls require your own accounts and are not proven by offline checks. Record organizer-provided offers in [CREDITS.md](CREDITS.md).
+
+## The Context Ladder
+
+Use this **starter-kit design exercise** to sharpen your demo. It is not the event's judging rubric; the event page says that rubric will be announced.
+
+| Level | The agent… | Try this |
+|---|---|---|
+| Reachable | Answers where people already are | Mention it in the chosen surface |
+| Situated | Uses surrounding context | Ask about the incident without pasting it into the prompt |
+| Native | Renders and acts in the surface's own idioms | Show a card and a visible follow-up or returned research result |
+
+Remove the surrounding context and compare the response. Explain what the agent can do because it belongs there, then demonstrate one complete interaction.
+
+## Verify and customize
 
 ```bash
 npm run verify
+npm run check-env
 ```
 
-![npm run verify — pre-flight, typecheck, tests, and a real MCP protocol round trip](assets/verify.gif)
+`verify` runs workspace typechecks, tests, and MCP protocol checks without `.env` or live credentials. `check-env` separately validates configured startup; it does not authenticate with sponsors. Optional recipe checks are documented beside their examples. Live Slack delivery, sponsor access, voice, and mobile hardware need separate validation.
 
-Typechecks all six packages, runs the component and safety tests, and drives the
-MCP server over the **real protocol** — initialize, tools/list, tools/call,
-resources/read. No credentials needed for any of it. It also names the three
-things it cannot prove, rather than implying they passed.
+Start editing here:
 
-### Requirements
+- [Shared agent](packages/agent-core/src/agent.ts) and [prompt](packages/agent-core/src/prompt.ts)
+- [Slack tools](apps/channel-slack/src/tools.tsx) and [native cards](apps/channel-slack/src/components.tsx)
+- [Incident workspace](apps/web/src/app/page.tsx) and [frontend actions](apps/web/src/components/app-control.tsx)
+- [Sponsor recipes](dev-docs/sponsors.md) and [developer docs](dev-docs/README.md)
 
-**Node.js 22+** — Channels needs global `WebSocket`. `nvm use` reads `.nvmrc`. Tier 1 needs a CopilotKit Intelligence project (free tier); there is no DIY path, because Intelligence owns the platform credentials and delivery.
-
----
-
-## How it fits together
-
-```
-packages/agent-core        ONE agent. Model, prompt, capabilities.
-  src/agent.ts               BuiltInAgent by default — swap for LangGraph, CrewAI,
-                             Mastra, Pydantic AI or Google ADK by returning an
-                             HttpAgent instead. Nothing else changes.
-  src/model.ts               OpenAI by default; one env var flips it to OpenRouter.
-  src/prompt.ts              How to behave inside someone else's workspace.
-  src/shared.ts              The browser-safe surface — prompt, schemas, notes.
-  src/capabilities/          Surface-agnostic implementations (Exa search).
-
-apps/local-chat            your terminal        — tier 0, one credential
-apps/channel-slack         Slack / Teams        — Channels, zero tunnel
-  src/channel.tsx            createChannel + handlers
-  src/components.tsx         agent-rendered native cards (rung 3)
-  src/tools.tsx              read_thread, search_web, confirm_action
-  src/durable.tsx            run_deep_work — the two-tier approval
-  src/server.ts              lifecycle — and why `ready()` is not proof of life
-apps/web                   the browser          — generative UI + /voice
-apps/mcp                   ChatGPT / Claude     — MCP server with a UI widget
-apps/durable               Trigger.dev          — work that outlives a chat turn
-apps/mobile                iOS / Android        — Expo, standalone (see below)
-```
-
-Every surface imports the same `makeAgent`. That is the whole point of [AG-UI](https://docs.copilotkit.ai): the agent does not know or care which surface it is talking through.
-
-Two deliberate exceptions, both documented where they live: **voice** cannot run `BuiltInAgent` because Realtime is a different model family, so it shares the prompt and capabilities instead; and **mobile** is not an npm workspace member, because React Native pins its own `react` and hoisting that can break the web app.
-
-### Why Slack needs no tunnel
-
-```
-Slack ──HTTPS, signed with a secret Intelligence holds──▶ CopilotKit Intelligence
-                                                                    │
-                          outbound websocket, authed by your key    ▼
-                                                            your local process
-```
-
-You never expose a port. The cost is that your process must be **long-running** — a Channels listener cannot live in a serverless handler. See [dev-docs/deploy.md](dev-docs/deploy.md).
-
----
-
-## Stack
-
-7 of these are **wired** — real code you can read, delete, or build on. 2 are
-**referenced** — named because they fit, with an honest note on what integrating
-them would take. The distinction is marked on each heading, because a logo on a
-banner is not an integration.
-
-
-### CopilotKit — Channels SDK · **wired**
-
-[Channels](https://github.com/CopilotKit/channels-sdk) brings any AG-UI agent into Slack, Microsoft Teams, Discord, Telegram, and WhatsApp with **native, interactive UI** — one JSX tree renders as Slack Block Kit or Teams Adaptive Cards, and a surface that cannot render a node skips it instead of failing. Intelligence manages the platform credentials and delivery; your agent, tools, and business logic stay yours.
-
-Pinned here as a tested pair: `@copilotkit/channels@0.9.2` + `@copilotkit/runtime@1.70.3`. Bump them together.
-
-[More about Channels →](https://docs.copilotkit.ai/slack) · [CopilotKit docs →](https://docs.copilotkit.ai)
-
-### CopilotKit — React & React Native · **wired**
-
-The same agent needs a frontend on every surface it lands on, and both come from
-CopilotKit rather than being hand-rolled.
-
-**Web** — `@copilotkit/react-core@1.70.1`. `apps/web` uses `CopilotKitProvider`,
-`CopilotSidebar`, `useComponent` (controlled generative UI), `useHumanInTheLoop`
-(the approval gate), `useFrontendTool` and `useAgentContext`. Worth knowing: the
-V2 surface lives at `@copilotkit/react-core/v2` — `@copilotkit/react-ui` is the V1
-surface and this kit does not need it.
-
-**Mobile** — `@copilotkit/react-native@1.70.1`. `apps/mobile` is an Expo app on the
-same agent: headless provider, a hand-rolled chat screen, and the same
-`propose_action` approval contract as Slack and web, so the agent behaves
-identically on a phone.
-
-Four things about the React Native SDK that the docs do not tell you, all verified
-against the published 1.70.1 bundles:
-
-- **Import from `@copilotkit/react-native/headless`, never the root barrel.** The
-  root entry imports `expo-document-picker` and `expo-file-system`
-  unconditionally; the headless subpath imports none of the optional native
-  peers, so the app needs no Metro stubs at all.
-- **`index.js` import order is load-bearing.** `react-native-get-random-values`
-  first (otherwise CopilotKit installs a `Math.random()` crypto shim and warns it
-  is not secure), then `@copilotkit/react-native/polyfills`, then the app — the
-  barrel overrides `global.fetch` and React Native's `InitializeCore` clobbers it
-  if imported too early.
-- **One polyfill import is enough on 1.70.1.** The barrel now installs streams,
-  encoding, crypto, DOMException and location plus streaming fetch. Older
-  versions only did streaming-fetch and needed all five granular subpaths.
-- **Render tool calls through `useRenderToolCall()`.** It resolves the renderer
-  *and* supplies `respond`, which is what makes an approval card answerable.
-  Walking the render registry by hand is a trap: the local `useRenderTool`
-  registry passes only `{ args, status }` with no `respond`, so the card renders
-  perfectly and silently cannot be answered.
-
-`apps/mobile` is deliberately **not** an npm workspace member — React Native pins
-its own `react` and `react-native`, and hoisting those can break `apps/web`. It
-installs and runs on its own.
-
-> Installs, resolves and typechecks with Expo-blessed versions (SDK 54, RN 0.81.5,
-> react 19.1.0). **Not run on a device** — that is the one surface here nobody has
-> launched. See `apps/mobile/README.md`.
-
-[React Native quickstart →](https://docs.copilotkit.ai/react-native) · [CopilotKit reference →](https://docs.copilotkit.ai/reference)
-
-### OpenAI · **wired**
-
-The default model provider. The kit runs on **`gpt-5.6-sol`**, with **`gpt-6-astra`** a one-line change away when a build needs the hardest end-to-end reasoning — and `gpt-5.6-luna` a one-line change the other way if hackathon credits start running out.
-
-Also behind two of the surfaces here: the **Realtime API** (`gpt-realtime-2.1` over WebRTC) drives `/voice`, and the **plugins** model — an MCP server plus skills plus optional UI — is what `apps/mcp` implements for agents living inside ChatGPT itself.
-
-[Models →](https://developers.openai.com/api/docs/models) · [Realtime →](https://developers.openai.com/api/docs/guides/realtime) · [Plugins →](https://developers.openai.com/plugins/)
-
-### OpenRouter · **wired**
-
-An AI gateway across hundreds of models, with cost-optimized routing and provider fallbacks. In this kit it is **live-demo insurance**: set `OPENROUTER_API_KEY` and the whole agent re-routes with no other change. If OpenAI rate-limits you at 14:00 with a demo at 15:30, that is the line that saves the day.
-
-[More about OpenRouter →](https://openrouter.ai/docs/quickstart)
-
-### Exa · **wired**
-
-Search built for agents, and the grounding layer for every surface here. The detail that matters: Exa's search types are a **latency dial**, and `instant` (~250ms) / `fast` (~450ms) are the only sane choices inside a chat thread — `deep-reasoning` can take 40 seconds and reads as a hung bot. The kit defaults to `fast` and the pre-flight check warns if you pick a slow one.
-
-`search_web` is only registered when `EXA_API_KEY` is present; without it the agent is told plainly that it has no web access rather than guessing.
-
-[More about Exa →](https://exa.ai/docs) · hosted MCP at `mcp.exa.ai/mcp`
-
-### Trigger.dev · **wired**
-
-Open-source background jobs in plain async code — queuing, retries, elastic scaling. Its **waitpoint tokens** are the natural partner to a Channels approval gate: a button click completes a `wait.forToken()`, and the task resumes to do work that outlives the chat turn.
-
-Wired up in `apps/durable` and exposed to Slack as the `run_deep_work` tool. See [dev-docs/durable-work.md](dev-docs/durable-work.md).
-
-[More about Trigger.dev →](https://trigger.dev/docs/quick-start)
-
-### Auth0 · **referenced**
-
-Identity for agents: **Token Vault** so the agent calls third-party APIs as *the asking user* rather than a service account, **CIBA** for out-of-band approval on someone's phone, and **FGA** for document-level access control in RAG. The natural escalation above an in-thread button.
-
-**Not integrated.** `apps/durable/src/approvals.ts` is the seam and it throws
-deliberately: the CIBA flow is clear (POST `/bc-authorize` → `auth_req_id` → poll
-`/oauth/token`) but the parameter set and polling error codes are not in the
-overview docs, and a plausible guess there 400s for reasons nobody can see. The
-Trigger.dev waitpoint is already waiting — completing it from an Auth0 callback
-changes nothing else in the chain.
-
-[More about Auth0 for AI Agents →](https://auth0.com/ai/docs)
-
-### Mozilla.ai · **referenced**
-
-`any-llm` (one interface across providers), `any-agent` (one interface across seven agent frameworks, plus OpenTelemetry traces and agent-as-a-judge evaluation), and **`mcpd`** — "requirements.txt for agentic systems", a daemon that manages MCP servers from declarative config. All open source.
-
-**Not integrated, and worth knowing why.** `mcpd` looked like the natural fit —
-one declarative file for the agent's MCP servers, working the same locally and in
-a container. But it exposes servers as **REST** (`/api/v1/servers/{server}/tools/{tool}`),
-not over the MCP protocol, so it is not a drop-in for `mcpServers` and would need
-a real adapter. `any-llm` and `any-agent` are Python and would fight a
-TypeScript-first kit.
-
-If you are building in Python, invert that: `any-agent` behind an AG-UI endpoint
-and every surface here works unchanged. Its graded traces are an underrated demo
-asset — showing *why* the agent did what it did lands harder than showing that it
-worked.
-
-[More about Mozilla.ai →](https://www.mozilla.ai/open-tools/choice-first-stack)
-
-### Ambiguous AI · **wired**
-
-A workspace of 17 productivity apps — Docs, Mail, Sheets, Chat, CRM, Calendar, Tasks and more — where AI coworkers hold their own identity and work on the same data as the team. Free for teams of five.
-
-The fastest *at work* integration available, because there is no admin consent screen and no per-object sharing dance:
-
-```bash
-npx ambiguous auth signup --name "My Agent" --human-email you@example.com
-```
-
-Wired as an MCP server in `packages/agent-core/src/capabilities/workplace.ts`, so
-the on-call agent can file the follow-up task and send the summary itself instead
-of telling a human to. Set `AMBIGUOUS_API_KEY` and the tools appear; leave it
-unset and the agent is never offered them.
-
-> Written against the documented MCP surface and typechecked, but **not run
-> against a live workspace** — that needs a key. Ten minutes to prove.
-
-[More about Ambiguous AI →](https://www.ambiguous.ai/)
-
----
-
-## Vibe coding
-
-Skills are pre-installed. Open the repo in Claude Code or Cursor and they are picked up automatically.
-
-```
-.agents/skills/      ← one copy
-.claude/skills   →   symlink
-.cursor/skills   →   symlink
-```
-
-`build-channels-agent` carries the **verified** Channels API surface plus a "common mistakes" list — the most common failure mode when writing Channels code with an LLM is inventing a plausible-looking API, and that skill is the antidote. [AGENTS.md](AGENTS.md) holds the repo-specific rules that are easy to get wrong (the `@ag-ui/client` dedupe pin, `jsxImportSource`, `maxSteps`).
-
-`.mcp.json` wires the CopilotKit docs MCP server and Exa's hosted MCP into your coding agent, so it can look things up live:
-
-```
-https://mcp.copilotkit.ai/mcp     https://mcp.exa.ai/mcp
-```
-
-To pull the rest of the CopilotKit skills:
-
-```bash
-npx skills add copilotkit/skills --full-depth -y
-```
-
----
-
-## Where to go next
-
-Honest status. What ships works and is typechecked; the rest is scaffolding you or your team can add.
-
-| Surface | Status |
-|---|---|
-| Terminal (tier 0) | **working** — reaches the model, verified |
-| Slack (managed Channel) | **working** — boots to real Channel activation; needs your Intelligence project to prove the round trip |
-| Microsoft Teams | swap `--adapter teams`; same JSX renders as Adaptive Cards |
-| Web — Next.js + generative UI | **working** — `next build` passes, `useComponent` / HITL / frontend tools wired |
-| Voice — OpenAI Realtime over WebRTC | **working** — ephemeral client secrets, `gpt-realtime-2.1` |
-| ChatGPT / Claude / Codex — MCP server | **working** — verified against the live protocol: initialize, tools/list, tools/call, resources/read |
-| Trigger.dev durable work + waitpoint approval | **wired** — typechecked; needs a Trigger.dev project to run |
-| Mobile — Expo + `@copilotkit/react-native` | **scaffolded** — installs, Expo-aligned, typechecks; **not** device-verified |
-| Ambiguous AI workplace (mail / tasks / CRM over MCP) | **wired** — typechecked; needs a key to prove against a live workspace |
-| Auth0 CIBA out-of-band approval | **referenced** — deliberately a throwing stub, not a guess |
-| Mozilla.ai | **referenced** — `mcpd` is REST, not MCP protocol, so it needs an adapter |
-| Discord / Telegram / WhatsApp | adapters ship in `@copilotkit/channels`; not wired here |
-
-Everything marked *working* was exercised, not just compiled. The two that are not
-say so, and `apps/mobile/README.md` and `apps/durable/src/approvals.ts` explain
-exactly what is left.
-
-This is a menu, not a checklist. See [Pick one surface](#pick-one-surface).
-
-**The two-tier approval is already built**, minus its last mile. `confirm_action`
-gates cheap things with an in-thread button that blocks the tool. `run_deep_work`
-handles the expensive ones: it creates a Trigger.dev waitpoint, hands the job to a
-durable task that parks on it, and posts an approval card — so the thread stays
-live while a job that outlives the conversation waits on a human. Approve, and the
-task wakes up and works. The remaining step is routing that same waitpoint through
-an Auth0 CIBA push instead of a channel button, for the actions where "somebody
-clicked in Slack" is not a strong enough claim about who approved it.
-
----
-
-## Documentation
-
-- **[Setup](dev-docs/setup.md)** · **[Channels](dev-docs/channels.md)** · **[Surfaces](dev-docs/surfaces.md)**
-- **[Tools, native UI & approval gates](dev-docs/tools-and-context.md)** · **[Model switching](dev-docs/model-switching.md)**
-- **[Deploy](dev-docs/deploy.md)** · **[Demo prompts](dev-docs/demo-prompts.md)** · **[Troubleshooting](dev-docs/troubleshooting.md)**
-- **[SUBMISSION.md](SUBMISSION.md)** — the five deliverables as a checklist
-- **[CREDITS.md](CREDITS.md)** — sponsor credits, to fill in at the opening session
-- **[research/](research/)** — the sponsor-by-sponsor research this kit was built from, including verified package versions and a teardown of the previous hackathon kit
-
-## License
-
-MIT.
-
----
-
-<div align="center">
-<sub>Built for <b>Agents, Everywhere: Bots, Channels, &amp; More</b> — 12 September 2026.</sub>
-</div>
+The repository includes Channels coding guidance in [.agents/skills](.agents/skills/) and conventions in [AGENTS.md](AGENTS.md). Keep secrets server-side and out of your submission.

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -1,60 +1,49 @@
 # Submission checklist
 
-Five deliverables, all due by **17:00**. Demos run 15:30–16:30, so in practice
-this needs to be written *before* you demo, not after.
+Use the [event page](https://sf.aitinkerers.org/p/agents-everywhere-bots-channels-more-global-hackathon)
+and organizer announcements for the final deadline, upload instructions, and
+judging rubric. The Context Ladder in this kit is design guidance, not the rubric.
 
-## 1. Title
-<!-- A clear name. Not a pun on "agent". -->
-
-## 2. Written description
-
-The brief asks for three specific things — answer all three explicitly:
+## Title and description
 
 **What you built**
-<!-- One paragraph. -->
+<!-- Explain the complete interaction your demo shows. -->
 
 **Who it is for**
-<!-- Name a real person in a real situation, not a market segment. -->
+<!-- Name a person in a concrete situation. -->
 
 **Why the context matters**
-<!-- The scoring question. What can this agent do *because* it lives here that
-     it could not do in a separate chat window? If the answer is "nothing, it's
-     just more convenient", you are on rung 1 of the Context Ladder — go back
-     and use the surface. -->
+<!-- What did the agent know or do because it lived in this surface? -->
 
-## 3. Public GitHub repository
+**Sponsor technologies used**
+<!-- Name the tools you actually used and the visible contribution of each. -->
 
-- [ ] Public, and it actually builds from a clean clone
-- [ ] `.env` is **not** committed (`git log --all --diff-filter=A -- .env` returns nothing)
-- [ ] README says what it is and how to run it in under ten lines
-- [ ] `npm run typecheck` passes
+## Public repository
 
-## 4. Two-minute video
+- [ ] A new participant can run the quickstart from a clean clone
+- [ ] The README lists the credentials and separate processes required
+- [ ] `npm run verify` passes; optional recipe checks pass if used
+- [ ] `.env`, tokens, generated traces with sensitive data, and account secrets are excluded
+- [ ] Sample data, session-only state, and unimplemented integrations are clearly labeled
 
-- [ ] Under 2:00
-- [ ] Opens on the surface, not on your editor
-- [ ] Shows one real interaction end to end — no narrating over dead air
-- [ ] Shows the approval gate being **declined** at least once
-- [ ] Audio is audible
+## Two-minute demo video
 
-> GitHub only inline-plays video uploaded through a comment box (a
-> `user-attachments` URL). Raw repo files and release assets serve
-> `application/octet-stream` with `nosniff`, so a committed `<video>` stays dead.
-> Drag the file into a GitHub comment, copy the resulting URL, then delete the
-> comment.
+- [ ] Show the surface and existing context before the prompt
+- [ ] Demonstrate one complete interaction
+- [ ] Show a visible result: an actual record, local state change, or research source links
+- [ ] If showing an approval, distinguish the decision from execution and demonstrate the resulting behavior
+- [ ] State which sponsor technologies made the interaction possible
+- [ ] Keep the video within the event's limit and check audio
 
-## 5. Social post
+See [demo prompts](dev-docs/demo-prompts.md) for a reproducible incident workflow.
 
-- [ ] Public
-- [ ] Tags the sponsors — OpenAI, CopilotKit, OpenRouter, plus whichever infra
-      partners you actually used (Exa, Trigger.dev, Auth0, Mozilla.ai,
-      Ambiguous AI) and your city's local sponsors
-- [ ] Links the repo
-- [ ] Has the video or a screenshot of the native card — a text-only post about
-      an agent that renders UI undersells it
+## Social post and final submission
 
-## Before you submit
+- [ ] Follow the organizer's posting and sponsor-tagging instructions
+- [ ] Link the public repository and video
+- [ ] Credit the sponsors you used and applicable local partners
+- [ ] Check the live integration once more before recording or submitting
+- [ ] Inspect the repository, video and screenshots for secrets
 
-- [ ] Someone who has never seen it ran the quickstart from a clean clone
-- [ ] `npm run channel:status` is clean
-- [ ] No secrets in the repo, the video, or the screenshots
+Prepare the post and submission for a human to publish; running the starter kit
+does not publish either automatically.

--- a/apps/channel-slack/src/approval.test.tsx
+++ b/apps/channel-slack/src/approval.test.tsx
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { it } from "node:test";
+import { renderToIR } from "@copilotkit/channels";
+import type { ApprovalDecision } from "durable/research";
+import { slackCodec } from "@copilotkit/channels/slack/codec";
+import { z } from "zod";
+import { approvalCard, settleApproval } from "./approval";
+
+type Dependencies = Parameters<typeof settleApproval>[3];
+const decision = { approved: true, decidedBy: "Priya" };
+const render = async (deps: Dependencies, click = decision) =>
+  JSON.stringify(renderToIR(await settleApproval("waitpoint_test", "run_test", click, deps)));
+
+for (const approved of [true, false]) {
+  it(`concurrent opposite clicks and replay preserve the first ${approved ? "approval" : "denial"}`, async () => {
+    let saved: ApprovalDecision | undefined;
+    const deps: Dependencies = {
+      // Model Trigger's atomic first-write and successful no-op on later clicks.
+      complete: async (_id, click) => { saved ??= click; return { success: true }; },
+      retrieve: async () => ({ status: "COMPLETED", output: saved }),
+    };
+    const first = { approved, decidedBy: "Priya" };
+    const opposite = { approved: !approved, decidedBy: "Alex" };
+    const cards = await Promise.all([render(deps, first), render(deps, opposite)]);
+    cards.push(await render(deps, opposite));
+    for (const card of cards) {
+      assert.match(card, approved ? /Approved by `Priya`/ : /Declined by `Priya`/);
+      assert.doesNotMatch(card, /Alex/);
+      if (approved) assert.doesNotMatch(card, /Nothing ran/);
+      else assert.doesNotMatch(card, /Research will run/);
+    }
+    assert.equal(new Set(cards).size, 1);
+  });
+}
+
+it("shows expiration when completing an expired token is a successful no-op", async () => {
+  const card = await render({
+    complete: async () => ({ success: true }),
+    retrieve: async () => ({ status: "TIMED_OUT", error: new Error("Timed out") }),
+  });
+  assert.match(card, /Approval expired/);
+  assert.doesNotMatch(card, /Approved by/);
+});
+
+it("does not render an accepted decision when retrieval fails", async () => {
+  await assert.rejects(render({
+    complete: async () => ({ success: true }),
+    retrieve: async () => { throw new Error("Trigger unavailable"); },
+  }), /Trigger unavailable/);
+});
+
+it("fails loudly on unconfirmed, malformed, or errored persisted outcomes", async () => {
+  for (const token of [
+    { status: "WAITING" as const },
+    { status: "COMPLETED" as const },
+    { status: "COMPLETED" as const, output: { approved: "false" } },
+    { status: "COMPLETED" as const, error: new Error("Unexpected token error") },
+  ]) {
+    await assert.rejects(render({
+      complete: async () => ({ success: true }),
+      retrieve: async () => token,
+    }));
+  }
+});
+
+const slackCardSchema = z.object({ attachments: z.array(z.object({
+  blocks: z.array(z.object({ type: z.string(), text: z.object({ text: z.string().max(3000) }).optional() })),
+})).optional(), blocks: z.array(z.object({ type: z.string(), text: z.object({ text: z.string().max(3000) }).optional() })).optional() });
+function cardSections(card: Parameters<typeof renderToIR>[0]) {
+  const rendered = slackCardSchema.parse(slackCodec.renderEgress(renderToIR(card)));
+  return [...(rendered.blocks ?? []), ...(rendered.attachments?.flatMap((attachment) => attachment.blocks) ?? [])]
+    .filter((block) => block.type === "section").flatMap((block) => block.text ? [block.text.text] : []);
+}
+const hostileText = "<!channel> <@U123> [guide](https://evil.example) **bold** `code`";
+it("approval questions stay literal through the actual Slack codec", () => {
+  const sections = cardSections(approvalCard(hostileText, "run_test", async () => {}));
+  assert.equal(sections[0], "`&lt;!channel&gt; &lt;@U123&gt; [guide](https://evil.example) **bold** 'code'`");
+  assert.match(sections[1], /Approval sends this question to Exa/);
+});
+for (const approved of [true, false]) {
+  it(`persisted ${approved ? "approver" : "decliner"} names stay literal through the Slack codec`, async () => {
+    const card = await settleApproval("wait_test", "run_test", decision, {
+      complete: async () => {},
+      retrieve: async () => ({ status: "COMPLETED", output: { approved, decidedBy: hostileText } }),
+    });
+    const text = cardSections(card).join("\n");
+    assert.match(text, /`&lt;!channel&gt; &lt;@U123&gt; \[guide\]\(https:\/\/evil.example\) \*\*bold\*\* 'code'`/);
+    assert.doesNotMatch(text, /<!channel>|<@U123>|<https:/);
+  });
+}
+it("approval renders the entire maximum-length question despite escape expansion", () => {
+  const question = "<&>".repeat(665) + "FINAL";
+  const sections = cardSections(approvalCard(question, "run_test", async () => {}));
+  const questionText = sections.slice(0, -1).map((text) => text.slice(1, -1)).join("");
+  assert.equal(questionText, question.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;"));
+});

--- a/apps/channel-slack/src/approval.tsx
+++ b/apps/channel-slack/src/approval.tsx
@@ -1,0 +1,71 @@
+import { Message, Section, Markdown, Header, Actions, Button, Context } from "@copilotkit/channels";
+import type { InteractionContext } from "@copilotkit/channels";
+import { approvalDecisionSchema, literalExcerpt } from "durable/research";
+import type { wait } from "@trigger.dev/sdk";
+import type { ApprovalDecision } from "durable/research";
+
+type RetrievedDecision = Pick<Awaited<ReturnType<typeof wait.retrieveToken>>, "status" | "output" | "error">;
+
+/** Completion is idempotent: a successful response need not accept this click. */
+export async function settleApproval(tokenId: string, runId: string, decision: ApprovalDecision, deps: {
+  complete: (id: string, decision: ApprovalDecision) => Promise<unknown>;
+  retrieve: (id: string) => Promise<RetrievedDecision>;
+}) {
+  await deps.complete(tokenId, decision);
+  // Trigger persists the first accepted decision. Replays and concurrent clicks
+  // must all display that same outcome, including the original decision maker.
+  const token = await deps.retrieve(tokenId);
+  if (token.status === "TIMED_OUT") {
+    return <Message><Section><Markdown>Approval expired. Nothing ran.</Markdown></Section></Message>;
+  }
+  if (token.error) throw token.error;
+  if (token.status !== "COMPLETED") {
+    throw new Error("Trigger has not confirmed the approval decision. Check the run before retrying.");
+  }
+  const saved = approvalDecisionSchema.parse(token.output);
+  const decidedBy = saved.decidedBy ?? "someone in this thread";
+  return saved.approved ? (
+    <Message accent="#2E7D5B"><Section><Markdown>{`Approved by ${literalExcerpt(decidedBy, 2000)}. Research will run in Trigger. Ask me to check ${runId} for results here.`}</Markdown></Section></Message>
+  ) : (
+    <Message><Section><Markdown>{`Declined by ${literalExcerpt(decidedBy, 2000)}. Nothing ran.`}</Markdown></Section></Message>
+  );
+}
+
+/** Keep untrusted questions literal and complete across Slack section limits. */
+export function approvalCard(request: string, runId: string, settle: (approved: boolean, ctx: InteractionContext<boolean>) => Promise<void>) {
+  // At most 400 code points per section leaves room for HTML escape expansion.
+  return (
+    <Message accent="#C4145F">
+      <Header>Approve web research</Header>
+      {Array.from(request).reduce<string[]>((chunks, char, index) => {
+        if (index % 400 === 0) chunks.push("");
+        chunks[chunks.length - 1] += char;
+        return chunks;
+      }, []).map((chunk) => <Section><Markdown>{literalExcerpt(chunk, 3000)}</Markdown></Section>)}
+      <Section>
+        <Markdown>{"Approval sends this question to Exa and searches public web sources. It does not read logs or change external systems."}</Markdown>
+      </Section>
+      <Actions>
+        <Button
+          value={true}
+          style="primary"
+          onClick={async (ctx) => {
+            await settle(true, ctx);
+          }}
+        >
+          Approve
+        </Button>
+        <Button
+          value={false}
+          style="danger"
+          onClick={async (ctx) => {
+            await settle(false, ctx);
+          }}
+        >
+          Cancel
+        </Button>
+      </Actions>
+      <Context>{`Research ${runId} · approval expires in 30 minutes. Ask me to check ${runId} to see results here; they are not pushed automatically.`}</Context>
+    </Message>
+  );
+}

--- a/apps/channel-slack/src/channel.tsx
+++ b/apps/channel-slack/src/channel.tsx
@@ -3,7 +3,7 @@ import { makeAgent, isSearchConfigured, isWorkplaceConfigured, WORKPLACE_CONTEXT
 import { required } from "./env";
 import { IncidentCard, Timeline, welcomeMessage } from "./components";
 import { proposeAction, readThread, searchTheWeb } from "./tools";
-import { isDurableConfigured, runDeepWork } from "./durable";
+import { isDurableConfigured, runDeepWork, checkDeepWork } from "./durable";
 
 // Tools are registered only when their credential is present, so the agent is
 // never handed a tool that will fail when it calls it.
@@ -11,7 +11,7 @@ const tools = [
   readThread,
   proposeAction,
   ...(isSearchConfigured() ? [searchTheWeb] : []),
-  ...(isDurableConfigured() ? [runDeepWork] : []),
+  ...(isDurableConfigured() ? [runDeepWork, checkDeepWork] : []),
 ];
 
 export const channel = createChannel({

--- a/apps/channel-slack/src/durable.tsx
+++ b/apps/channel-slack/src/durable.tsx
@@ -1,49 +1,38 @@
 /**
- * The two-tier approval, from the Slack side.
- *
- * `confirm_action` (in tools.tsx) gates cheap things: it blocks the tool with
- * `awaitChoice` and the whole thing is over in seconds.
- *
- * This is the other tier. The work is too slow to hold a chat turn open, so:
- *
- *   1. create a Trigger.dev waitpoint token
- *   2. trigger the durable task, which immediately parks on that token
- *   3. post an approval card and RETURN — the thread stays live
- *   4. a button click completes the token; the task wakes up and works
- *
- * Only registered when TRIGGER_SECRET_KEY is set, so the kit still runs without
- * a Trigger.dev account.
+ * Queue approved Exa research without holding the conversation open. The worker
+ * persists in Trigger; check_deep_work retrieves its outcome in a later turn.
+ * Inline approval buttons require the listener to remain running until clicked.
  */
-import {
-  defineChannelTool,
-  Message,
-  Header,
-  Section,
-  Markdown,
-  Context,
-  Actions,
-  Button,
-} from "@copilotkit/channels";
-import type { InteractionContext, MessageRef } from "@copilotkit/channels";
-import { tasks, wait } from "@trigger.dev/sdk";
+import { defineChannelTool } from "@copilotkit/channels";
+import type { InteractionContext } from "@copilotkit/channels";
+import { tasks, runs, wait } from "@trigger.dev/sdk";
 import { z } from "zod";
+import { approvalCard, settleApproval } from "./approval";
 import type { deepWork } from "durable/trigger/deep-work";
+import { reportResearch, requireResearchConfig, researchOriginSchema } from "durable/research";
 
 export function isDurableConfigured(): boolean {
-  return Boolean(process.env.TRIGGER_SECRET_KEY);
+  if (!process.env.TRIGGER_SECRET_KEY?.trim()) return false;
+  requireResearchConfig(process.env);
+  return true;
 }
 
 export const runDeepWork = defineChannelTool({
   name: "run_deep_work",
   description:
-    "Hand a slow, long-running job to the durable worker: anything that would take more than about thirty seconds, needs retries, or must survive a restart. It requires human approval before it starts. Use this INSTEAD of trying to do the work inside the conversation.",
+    "Queue Exa web research after human approval. This searches public web sources; it cannot read logs or execute external actions. The user must ask check_deep_work with the run ID to receive results in this thread.",
   parameters: z.object({
-    request: z.string().describe("What the work is, in one sentence, from the user's point of view."),
-    consequence: z
-      .string()
-      .describe("What actually happens in the real world once this is approved."),
+    request: z.string().trim().min(1).max(2000).describe("The public-web research question."),
   }),
-  async handler({ request, consequence }, { thread, user, message }) {
+  async handler({ request }, { thread }) {
+    requireResearchConfig(process.env);
+    const origin = researchOriginSchema.parse({
+      platform: thread.platform,
+      channelCode: process.env.CHANNEL_CODE,
+      // The concrete SDK Thread exposes this documented property; its UI
+      // interface omits it in 0.9.2. Validate at runtime rather than cast.
+      conversationKey: "conversationKey" in thread ? thread.conversationKey : undefined,
+    });
     // A generous timeout: the ceiling is a human's attention, not the model's.
     const token = await wait.createToken({
       timeout: "30m",
@@ -51,76 +40,47 @@ export const runDeepWork = defineChannelTool({
     });
 
     // Type-only import of the task, so the task's code is never bundled here.
-    await tasks.trigger<typeof deepWork>("deep-work", {
+    const run = await tasks.trigger<typeof deepWork>("deep-work", {
       tokenId: token.id,
       request,
-      origin: {
-        platform: message?.platform ?? "unknown",
-        channelCode: process.env.CHANNEL_CODE ?? "unknown",
-      },
+      origin,
     });
-
-    // `InteractionContext` carries `thread`, `message`, `action`, `values`,
-    // `user`, `actor`, `platform` and an optional `openModal` — but NOT a
-    // `messageRef`, whatever the UI reference implies. So keep the ref from
-    // `thread.post()` in a binding the click handlers close over. Inline
-    // handlers are in-process only anyway, so their lifetime matches this one.
-    let cardRef: MessageRef | undefined;
 
     const settle = async (approved: boolean, ctx: InteractionContext<boolean>) => {
       // Credit the person who actually clicked, not whoever asked.
       const decidedBy = ctx.user?.name ?? ctx.actor?.id ?? "someone in this thread";
-      await wait.completeToken(token.id, { approved, decidedBy });
+      const outcome = await settleApproval(token.id, run.id, { approved, decidedBy }, {
+        complete: (id, decision) => wait.completeToken(id, decision),
+        retrieve: (id) => wait.retrieveToken(id),
+      });
 
-      const outcome = approved ? (
-        <Message accent="#2E7D5B">
-          <Section>
-            <Markdown>{`Approved by ${decidedBy}. Working on it \u2014 this keeps running even if the thread goes quiet.`}</Markdown>
-          </Section>
-        </Message>
-      ) : (
-        <Message>
-          <Section>
-            <Markdown>{`Declined by ${decidedBy}. Nothing ran.`}</Markdown>
-          </Section>
-        </Message>
-      );
-
-      if (cardRef) await ctx.thread.update(cardRef, outcome);
+      // Only the ref stamped for this live interaction can be updated safely.
+      if (ctx.message.ref.id) await ctx.thread.update(ctx.message.ref, outcome);
       else await ctx.thread.post(outcome);
     };
 
-    cardRef = await thread.post(
-      <Message accent="#C4145F">
-        <Header>Waiting on you before this starts</Header>
-        <Section>
-          <Markdown>{`**${request}**\n\n${consequence}`}</Markdown>
-        </Section>
-        <Actions>
-          <Button
-            value={true}
-            style="primary"
-            onClick={async (ctx) => {
-              await settle(true, ctx);
-            }}
-          >
-            Approve
-          </Button>
-          <Button
-            value={false}
-            style="danger"
-            onClick={async (ctx) => {
-              await settle(false, ctx);
-            }}
-          >
-            Cancel
-          </Button>
-        </Actions>
-        <Context>{`waitpoint ${token.id} \u00b7 expires in 30 minutes`}</Context>
-      </Message>,
-    );
+    await thread.post(approvalCard(request, run.id, settle));
 
     // Return immediately. The agent must NOT wait here — that is the whole point.
-    return "Queued the job and posted an approval card. Tell the user it is waiting on their approval and that it will keep running on its own once approved. Do not attempt the work yourself.";
+    return `Queued Exa research ${run.id} and posted an approval card. After approval, ask me to check ${run.id} in this conversation. Results are retrieved on request, not pushed automatically. The worker survives restarts, but these inline approval buttons require the listener to stay running until clicked. Do not attempt the work yourself.`;
+  },
+});
+
+/** Retrieve by visible run ID; origin validation also works after a listener restart. */
+export const checkDeepWork = defineChannelTool({
+  name: "check_deep_work",
+  description: "Check a previously queued Exa research run and show its status or sources in its original conversation. Use the run ID shown on the approval card.",
+  parameters: z.object({ runId: z.string().regex(/^run_[a-zA-Z0-9]+$/) }),
+  async handler({ runId }, { thread }) {
+    return reportResearch(runId, researchOriginSchema.parse({
+      platform: thread.platform,
+      channelCode: process.env.CHANNEL_CODE,
+      // The concrete SDK Thread exposes this documented property; its UI
+      // interface omits it in 0.9.2. Validate at runtime rather than cast.
+      conversationKey: "conversationKey" in thread ? thread.conversationKey : undefined,
+    }), {
+      retrieve: (id) => runs.retrieve<typeof deepWork>(id),
+      post: async (text) => { await thread.post(text); },
+    });
   },
 });

--- a/apps/channel-slack/src/research-results.test.tsx
+++ b/apps/channel-slack/src/research-results.test.tsx
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { renderToIR } from "@copilotkit/channels";
+import { slackCodec } from "@copilotkit/channels/slack/codec";
+import { z } from "zod";
+import { reportResearch } from "durable/research";
+
+const origin = { platform: "slack", channelCode: "research", conversationKey: "original-thread" };
+const payload = { tokenId: "wait_123", request: "Find sources", origin };
+const renderedSchema = z.object({ blocks: z.array(z.object({
+  type: z.literal("section"), text: z.object({ text: z.string().max(3000) }),
+})).max(50) });
+
+async function renderResults(findings: { title: string; url: string; highlight?: string }[]) {
+  const blocks: string[] = [];
+  await reportResearch("run_123", origin, {
+    retrieve: async () => ({ status: "COMPLETED", payload, output: { status: "done", findings } }),
+    // Exercise the same string -> IR -> Slack path as check_deep_work.
+    post: async (text) => {
+      const rendered = renderedSchema.parse(slackCodec.renderEgress(renderToIR(text)));
+      blocks.push(...rendered.blocks.map((block) => block.text.text));
+    },
+  });
+  return blocks;
+}
+
+test("all eight maximum-sized references survive the actual Slack codec", async () => {
+  const findings = Array.from({ length: 8 }, (_, i) => ({
+    title: "T".repeat(120), highlight: "H".repeat(300), url: `https://example.com/source-${i + 1}`,
+  }));
+  const blocks = await renderResults(findings);
+  for (const hit of findings) assert.ok(blocks.some((text) => text.includes(hit.url)), `missing ${hit.url}`);
+});
+
+test("long source URLs stay complete while oversized URLs are visibly omitted", async () => {
+  const usable = `https://example.com/${"a".repeat(2800)}`;
+  const oversized = `https://example.com/${"b".repeat(4000)}`;
+  const blocks = await renderResults([
+    { title: "T".repeat(120), highlight: "H".repeat(300), url: usable },
+    { title: "Oversized", url: oversized },
+  ]);
+  assert.ok(blocks.some((text) => text.includes(usable)));
+  assert.ok(blocks.some((text) => /URL omitted.*too long/.test(text)));
+  assert.ok(blocks.every((text) => !text.includes("b".repeat(100))));
+});
+
+test("untrusted source controls cannot create Slack mentions or extra links", async () => {
+  const blocks = await renderResults([{
+    title: "<!channel> [click](https://evil.example) `code` \u0010CODE0\u0010",
+    highlight: "<@U123> & <!here>\n```\n[go](https://evil.example)",
+    url: "https://example.com/path?q=a&b=c",
+  }, { title: "Unsafe", url: "javascript:alert(1)" }]);
+  const text = blocks.join("\n");
+  assert.doesNotMatch(text, /<!channel>|<!here>|<@U123>|<https:\/\/evil.example|[\u0000-\u0008\u000b-\u001f]/);
+  assert.match(text, /https:\/\/example.com\/path\?q=a&amp;b=c/);
+  assert.match(text, /URL omitted.*HTTP/);
+});
+
+
+test("URL Markdown delimiters are encoded without changing the source target", async () => {
+  const url = "https://example.com/a__b__c(1)?q=**test**~x~";
+  const blocks = await renderResults([{ title: "Reference", url }]);
+  const link = blocks.join("\n").match(/<(https:[^|>]+)\|Source 1>/);
+  assert.ok(link, "expected a complete rendered Slack source link");
+  assert.equal(decodeURIComponent(link[1]), url);
+});
+
+test("escape expansion is included in the section budget", async () => {
+  const blocks = await renderResults([{
+    title: "<>&".repeat(120), highlight: "<>&".repeat(300),
+    url: `https://example.com/?${"&".repeat(500)}`,
+  }]);
+  assert.ok(blocks.some((text) => text.includes(`https://example.com/?${"&amp;".repeat(500)}`)));
+});

--- a/apps/channel-slack/src/tools.test.tsx
+++ b/apps/channel-slack/src/tools.test.tsx
@@ -1,16 +1,34 @@
-/**
- * Tool tests — the safety properties, mostly.
- *
- * A channel tool handler takes `(args, ChannelToolContext)`, and these tools
- * touch only the context's `thread`. So a stub thread is enough to assert the
- * two behaviours that actually matter: that the agent is told to stop dead when
- * a human declines, and that missing history degrades into a legible
- * instruction rather than a silent empty array.
- */
 import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
-import { renderToIR } from "@copilotkit/channels";
+import { createChannel, Thread } from "@copilotkit/channels";
+import { startChannelsWithGatewayControl } from "@copilotkit/channels-intelligence";
+// Pinned SDK's offline gateway fixture: exercises the actual managed delivery
+// adapter, rendering and action registry without accounts or network calls.
+import { DeliveryTestGateway, preparedDelivery } from "../../../node_modules/@copilotkit/channels-intelligence/dist/delivery-test-gateway.js";
+import { z } from "zod";
 import { proposeAction, readThread } from "./tools";
+
+// The SDK fixture predates the required stable providerMessageId ack field.
+class ManagedGateway extends DeliveryTestGateway {
+  override async join(topic: string, payload: unknown) {
+    const channel = await super.join(topic, payload);
+    return {
+      ...channel,
+      push: async (event: string, packet: unknown) => {
+        const ack = z.object({ result: z.record(z.string(), z.unknown()) }).passthrough()
+          .parse(await channel.push(event, packet));
+        return { ...ack, result: { ...ack.result, providerMessageId: "pid_v1_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ" } };
+      },
+    };
+  }
+}
+
+function concreteThread(value: unknown): Thread {
+  // createChannel's StatefulThread type narrows state() incompatibly with the
+  // tool context in 0.9.2; verify the actual SDK instance instead of casting.
+  assert.ok(value instanceof Thread);
+  return value;
+}
 
 /** Only the methods these tools call; the rest of Thread is irrelevant here. */
 const stubContext = (thread: Record<string, unknown>) =>
@@ -52,44 +70,77 @@ describe("propose_action", () => {
     reversible: true,
   };
 
-  const choiceTree = (fn: ReturnType<typeof mock.fn>) =>
-    JSON.stringify(renderToIR(fn.mock.calls[0]!.arguments[0] as never));
-
-  it("blocks on awaitChoice and tells the agent to proceed only once approved", async () => {
-    const awaitChoice = mock.fn(async () => true);
-    const result = await proposeAction.handler(args, stubContext({ awaitChoice }));
-
-    assert.equal(awaitChoice.mock.callCount(), 1);
-    assert.match(String(result), /approved/i);
-    assert.match(String(result), /report exactly what you did/i);
-  });
-
-  it("tells the agent to stop dead when the responder holds", async () => {
-    const awaitChoice = mock.fn(async () => false);
-    const result = await proposeAction.handler(args, stubContext({ awaitChoice }));
-    const text = String(result);
-
-    assert.match(text, /do not take the action/i);
-    // The failure mode worth guarding: an agent that reads a refusal as an
-    // invitation to find another way in.
-    assert.match(text, /do not offer a workaround/i);
-    assert.doesNotMatch(text, /\bapproved\b/i);
-  });
-
-  it("puts both an approve and a hold control in front of the human", async () => {
-    const awaitChoice = mock.fn(async () => false);
-    await proposeAction.handler(args, stubContext({ awaitChoice }));
-    const tree = choiceTree(awaitChoice);
-
-    assert.ok(tree.includes("Approve"));
-    assert.ok(tree.includes("Hold"));
-    assert.ok(tree.includes(args.blastRadius));
-  });
-
-  it("says out loud when an action is not easily reversible", async () => {
-    const awaitChoice = mock.fn(async () => false);
-    await proposeAction.handler({ ...args, reversible: false }, stubContext({ awaitChoice }));
-
-    assert.match(choiceTree(awaitChoice), /NOT easily reversible/);
-  });
+  for (const choice of ["Approve", "Hold"]) {
+    it(`posts a real managed card and reports ${choice} on a later delivery`, { timeout: 10_000 }, async () => {
+      const gateway = new ManagedGateway();
+      const channel = createChannel({ name: "support", identifyUser: "platform" });
+      let result: unknown;
+      channel.onMessage(async ({ thread }) => {
+        try {
+          assert.equal(thread.supportsBlockingChoice, false);
+          result = await proposeAction.handler({ ...args, reversible: false }, { thread: concreteThread(thread), user: { id: "u1", name: "Priya" }, actor: { id: "a1", kind: "human" }, platform: "slack" });
+        } catch (error) { result = String(error); throw error; }
+      });
+      const runCanonical = mock.fn();
+      const handle = await startChannelsWithGatewayControl([channel], {
+        session: gateway,
+        scope: { projectId: 1, channelName: "support" },
+        runtimeInstanceId: "rti_proposal",
+        runCanonical: async (args) => {
+          // Neither the proposal handler nor the click resumes an agent.
+          runCanonical();
+          return args.execute({});
+        },
+        loadHistory: async () => [],
+      });
+      try {
+        const proposalDelivery = preparedDelivery("proposal", "slack", { kind: "text", text: "Propose a rollback" });
+        await gateway.deliver(proposalDelivery);
+        assert.match(String(result), /decision pending/, JSON.stringify(gateway.packets));
+        assert.match(String(result), /Do not take the action, call write tools, or offer a workaround/);
+        const payloads = gateway.packets.map(({ payload }) => payload);
+        const card = payloads.find((payload) => payload.kind === "slack.message.create");
+        assert.ok(card, "managed adapter must post the proposal before ending the delivery");
+        assert.match(JSON.stringify(card), /NOT easily reversible/);
+        assert.match(JSON.stringify(card), /All web traffic/);
+        assert.match(JSON.stringify(card), /Approve/);
+        assert.match(JSON.stringify(card), /Hold/);
+        // Read the real Slack action ID generated by Channels, then deliver it
+        // through the gateway in a separate (nonblocking) interaction turn.
+        const blocks = z.array(z.object({ type: z.string(), elements: z.array(z.unknown()).optional() })).parse(card.blocks);
+        const buttons = blocks.flatMap((block) => block.type === "actions" ? block.elements ?? [] : [])
+          .map((element) => z.object({ type: z.literal("button"), text: z.object({ text: z.string() }), action_id: z.string() }).parse(element));
+        const button = buttons.find((element) => element.text.text === choice);
+        assert.ok(button);
+        const clickDelivery = preparedDelivery("proposal_click", "slack", {
+          kind: "interaction",
+          actionId: button.action_id,
+          messageRef: { id: "pref_v1_proposal_message_123" },
+        });
+        await gateway.deliver({ ...proposalDelivery, deliveryId: clickDelivery.deliveryId, turn: clickDelivery.turn });
+        const update = gateway.packets.map(({ payload }) => payload).find((payload) => payload.kind === "slack.message.replace");
+        assert.ok(update, "click must replace the proposal with the decision");
+        assert.match(JSON.stringify(update), /No action was executed/);
+        assert.match(JSON.stringify(update), choice === "Approve" ? /Approved proposal/ : /Do not take the action or offer a workaround/);
+        // The SDK keeps both action IDs registered after replacing the card.
+        // Replay the first choice, then deliver a stale opposite choice: neither
+        // may overwrite the first recorded decision (including an initial Hold).
+        const oppositeButton = buttons.find((element) => element.text.text !== choice);
+        assert.ok(oppositeButton);
+        for (const [index, actionId] of [button.action_id, oppositeButton.action_id].entries()) {
+          const replayDelivery = preparedDelivery(`proposal_replay_${index}`, "slack", {
+            kind: "interaction",
+            actionId,
+            messageRef: { id: "pref_v1_proposal_message_123" },
+          });
+          await gateway.deliver({ ...proposalDelivery, deliveryId: replayDelivery.deliveryId, turn: replayDelivery.turn });
+        }
+        const updates = gateway.packets.map(({ payload }) => payload).filter((payload) => payload.kind === "slack.message.replace");
+        assert.equal(updates.length, 1, "duplicate and opposite clicks must preserve the first decision");
+        assert.equal(runCanonical.mock.callCount(), 0, "click reporting must not automatically resume the agent");
+      } finally {
+        await handle.stop();
+      }
+    });
+  }
 });

--- a/apps/channel-slack/src/tools.tsx
+++ b/apps/channel-slack/src/tools.tsx
@@ -2,8 +2,8 @@
  * The on-call agent's tools.
  *
  * A channel tool handler receives the LIVE thread, which is what makes the
- * approval gate below possible: the tool stops mid-execution, posts a card, and
- * blocks until a human clicks.
+ * proposal below possible: it posts a card and returns. A later click reports
+ * the decision; it does not resume the agent or execute an action.
  *
  * The return value is what the *agent* reads back, not what the user sees.
  * Return raw data (it is JSON-stringified for you) or a short natural-language
@@ -19,6 +19,7 @@ import {
   Actions,
   Button,
 } from "@copilotkit/channels";
+import type { InteractionContext } from "@copilotkit/channels";
 import { searchWeb, searchWebParameters } from "agent-core";
 import { z } from "zod";
 
@@ -52,48 +53,59 @@ export const searchTheWeb = defineChannelTool({
 });
 
 /**
- * The approval gate.
- *
- * `awaitChoice` posts a picker and BLOCKS this handler until someone clicks.
- * Because the agent is mid-tool-call, it cannot proceed past a refusal — which
- * is the difference between a bot that asks permission and one that asks
- * forgiveness. An outage is exactly when people feel entitled to skip this, and
- * exactly when skipping it makes things worse.
- *
- * Managed Slack delivers button clicks, so this fires on the default path.
+ * Managed delivery cannot block on awaitChoice. Post a proposal and let a later
+ * interaction report the decision. This demo has no production executor.
+ * Inline handlers require one listener instance that stays running until click.
  */
 export const proposeAction = defineChannelTool({
   name: "propose_action",
   description:
-    "Ask for approval before anything that touches production — restarting, scaling, rolling back, failing over, clearing a queue, or paging someone. Call this FIRST and only continue if it returns approval.",
+    "Post an action proposal for human review. This returns pending immediately. Stop after posting: do not execute the action or call write tools. A later click reports a decision only; it does not execute anything or resume you.",
   parameters: z.object({
-    action: z.string().describe("What you are about to do, in one plain sentence."),
+    action: z.string().describe("The proposed action, in one plain sentence."),
     blastRadius: z
       .string()
       .describe("What this affects if it goes wrong. Be specific and pessimistic."),
     reversible: z.boolean().describe("Whether this can be undone in under a minute."),
   }),
   async handler({ action, blastRadius, reversible }, { thread }) {
-    const approved = await thread.awaitChoice<boolean>(
+    // The SDK retains inline action handlers after a message replacement. Queue
+    // clicks and settle only after a successful update, so stale/opposite clicks
+    // cannot overwrite a decision and a failed update remains retryable.
+    let settled = false;
+    let previousReport = Promise.resolve();
+    const reportDecision = (approved: boolean, ctx: InteractionContext<boolean>) => {
+      const report = async () => {
+        if (settled) return;
+        const decision = approved
+          ? "Approved proposal. No action was executed."
+          : "Held by the responder. No action was executed. Do not take the action or offer a workaround.";
+        // Use the interaction's thread, whose delivery is live now.
+        await ctx.thread.update(ctx.message.ref, `${decision}\n\nProposal: ${action}`);
+        settled = true;
+      };
+      previousReport = previousReport.then(report, report);
+      return previousReport;
+    };
+    await thread.post(
       <Message accent="#C4145F">
-        <Header>Approve before I touch production</Header>
+        <Header>Review action proposal</Header>
         <Section>
           <Markdown>{`**${action}**\n\nBlast radius: ${blastRadius}`}</Markdown>
         </Section>
         <Context>{reversible ? "Reversible in under a minute" : "NOT easily reversible"}</Context>
+        <Context>Demo proposal only. Clicking records a decision; it executes nothing.</Context>
         <Actions>
-          <Button value={true} style="primary">
+          <Button value={true} style="primary" onClick={async (ctx) => { await reportDecision(true, ctx); }}>
             Approve
           </Button>
-          <Button value={false} style="danger">
+          <Button value={false} style="danger" onClick={async (ctx) => { await reportDecision(false, ctx); }}>
             Hold
           </Button>
         </Actions>
       </Message>,
     );
 
-    return approved
-      ? "Approved. Proceed, then report exactly what you did and what changed."
-      : "Held by the responder. Do not take the action, do not offer a workaround, and say plainly that nothing was changed.";
+    return "Proposal posted; decision pending. Stop here. Do not take the action, call write tools, or offer a workaround. A later click only reports the decision; no action is executed and the agent does not automatically resume.";
   },
 });

--- a/apps/durable/package.json
+++ b/apps/durable/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "npx trigger.dev@latest dev",
     "deploy": "npx trigger.dev@latest deploy",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test 'src/**/*.test.ts'"
   },
   "dependencies": {
     "@trigger.dev/sdk": "^4.5.16",
@@ -16,6 +17,7 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./trigger/*": "./src/trigger/*.ts"
+    "./trigger/*": "./src/trigger/*.ts",
+    "./research": "./src/research.ts"
   }
 }

--- a/apps/durable/src/research.test.ts
+++ b/apps/durable/src/research.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { executeResearch, reportResearch, requireResearchConfig, type ResearchPayload } from "./research";
+
+const payload: ResearchPayload = {
+  tokenId: "wait_123", request: "Find incident mitigation references",
+  origin: { channelCode: "incident-agent", platform: "slack", conversationKey: "workspace:channel:thread-1" },
+};
+const findings = [{ title: "Mitigation", url: "https://example.com/mitigation", highlight: "Roll back the change." }];
+
+test("approved research searches; reporting uses the captured original thread and includes sources", async () => {
+  let searches = 0;
+  const output = await executeResearch(payload, {
+    waitForDecision: async () => ({ ok: true, output: { approved: true } }),
+    search: async (request) => { assert.equal(request, payload.request); searches++; return findings; },
+  });
+  const posts: string[] = [];
+  await reportResearch("run_123", payload.origin, {
+    retrieve: async () => ({ status: "COMPLETED", payload, output }),
+    post: async (text) => { posts.push(text); },
+  });
+  assert.equal(searches, 1);
+  assert.match(posts[0], /run_123/);
+  assert.match(posts.join("\n"), /https:\/\/example.com\/mitigation/);
+});
+
+for (const status of ["declined", "timed_out"] as const) {
+  test(`${status} never searches and is reported`, async () => {
+    const output = await executeResearch(payload, {
+      waitForDecision: async () => status === "declined" ? { ok: true, output: { approved: false } } : { ok: false },
+      search: async () => { assert.fail("must not search"); },
+    });
+    assert.equal(output.status, status);
+    let posted = "";
+    await reportResearch("run_123", payload.origin, {
+      retrieve: async () => ({ status: "COMPLETED", payload, output }),
+      post: async (text) => { posted = text; },
+    });
+    assert.match(posted, status === "declined" ? /declined/i : /timed out/i);
+  });
+}
+
+for (const output of [{ approved: "false" }, { approved: "true" }, { approved: 1 }, { approved: {} }, { approved: null }, {}, null, undefined]) {
+  test(`malformed persisted decision ${JSON.stringify(output)} rejects without searching`, async () => {
+    let searches = 0;
+    await assert.rejects(executeResearch(payload, {
+      waitForDecision: async () => ({ ok: true, output }),
+      search: async () => { searches++; return findings; },
+    }), { name: "ZodError" });
+    assert.equal(searches, 0);
+  });
+}
+
+test("search failures reject the worker and failed Trigger status is reported", async () => {
+  const failure = new Error("Exa unavailable");
+  await assert.rejects(executeResearch(payload, {
+    waitForDecision: async () => ({ ok: true, output: { approved: true } }),
+    search: async () => { throw failure; },
+  }), (error) => error === failure);
+  let posted = "";
+  await reportResearch("run_123", payload.origin, {
+    retrieve: async () => ({ status: "FAILED", payload }),
+    post: async (text) => { posted = text; },
+  });
+  assert.match(posted, /FAILED/);
+});
+
+test("cannot retrieve another thread's research", async () => {
+  await assert.rejects(reportResearch("run_123", { ...payload.origin, conversationKey: "another-thread" }, {
+    retrieve: async () => ({ status: "COMPLETED", payload, output: { status: "done", findings } }),
+    post: async () => { assert.fail("must not post private findings"); },
+  }), /original conversation/);
+});
+
+test("notification failures surface independently from completed research", async () => {
+  await assert.rejects(reportResearch("run_123", payload.origin, {
+    retrieve: async () => ({ status: "COMPLETED", payload, output: { status: "done", findings } }),
+    post: async () => { throw new Error("delivery unavailable"); },
+  }), /delivery unavailable/);
+});
+
+test("missing Exa returned as text cannot be mistaken for research success", async () => {
+  await assert.rejects(executeResearch(payload, {
+    waitForDecision: async () => ({ ok: true, output: { approved: true } }),
+    search: async () => "Web search is not configured",
+  }), /Web search is not configured/);
+});
+
+for (const name of ["EXA_API_KEY", "TRIGGER_PROJECT_REF", "TRIGGER_SECRET_KEY"] as const) {
+  test(`missing ${name} fails before queueing research`, () => {
+    const env = { EXA_API_KEY: "test-key", TRIGGER_PROJECT_REF: "proj_123", TRIGGER_SECRET_KEY: "test-key" };
+    assert.throws(() => requireResearchConfig({ ...env, [name]: "   " }), new RegExp(name));
+  });
+}
+test("placeholder Trigger project is rejected", () => {
+  assert.throws(() => requireResearchConfig({ EXA_API_KEY: "test", TRIGGER_PROJECT_REF: "proj_replace_me", TRIGGER_SECRET_KEY: "test" }), /TRIGGER_PROJECT_REF/);
+});

--- a/apps/durable/src/research.ts
+++ b/apps/durable/src/research.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+
+const nonempty = z.string().trim().min(1);
+export const researchOriginSchema = z.object({
+  platform: nonempty,
+  channelCode: nonempty,
+  conversationKey: nonempty,
+});
+export const researchPayloadSchema = z.object({
+  tokenId: nonempty,
+  request: nonempty.max(2000),
+  origin: researchOriginSchema,
+});
+export type ResearchOrigin = z.infer<typeof researchOriginSchema>;
+export type ResearchPayload = z.infer<typeof researchPayloadSchema>;
+export const approvalDecisionSchema = z.object({
+  approved: z.boolean(),
+  decidedBy: nonempty.optional(),
+});
+export type ApprovalDecision = z.infer<typeof approvalDecisionSchema>;
+const findingsSchema = z.array(z.object({
+  title: z.string(), url: z.url(), highlight: z.string().optional(),
+}));
+const resultSchema = z.discriminatedUnion("status", [
+  z.object({ status: z.literal("done"), findings: findingsSchema }),
+  z.object({ status: z.literal("declined") }),
+  z.object({ status: z.literal("timed_out") }),
+]);
+
+// Slack's string transport becomes one section capped at 3,000 characters.
+// Budget the escaped message, keep each URL whole, and post sources separately.
+const sectionLimit = 3000;
+function escapeText(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function literalExcerpt(text: string, limit: number): string {
+  // Code spans prevent source-supplied Markdown links from becoming controls.
+  const plain = text.replace(/[\u0000-\u001f\u007f]/g, " ").replace(/`/g, "'");
+  let result = "";
+  for (const char of plain) {
+    const escaped = escapeText(char);
+    if (result.length + escaped.length > limit - 2) break;
+    result += escaped;
+  }
+  return result ? `\`${result}\`` : "";
+}
+
+function referenceMessage(hit: z.infer<typeof findingsSchema>[number], index: number): string {
+  const label = `Source ${index + 1}`;
+  const url = new URL(hit.url);
+  let link: string;
+  if (!["http:", "https:"].includes(url.protocol) || /[\u0000-\u0020\u007f]/.test(hit.url) || url.username || url.password) {
+    link = `${label}: URL omitted (requires an HTTP(S) URL without credentials or control characters).`;
+  } else {
+    // Encode Markdown delimiters before the codec translates this link to Slack.
+    const encoded = hit.url.replace(/[()*_~`<>|\[\]\\]/g, (char) =>
+      `%${char.charCodeAt(0).toString(16).toUpperCase()}`);
+    link = `[${label}](${escapeText(encoded)})`;
+    if (link.length > sectionLimit) {
+      link = `${label}: URL omitted (too long for Slack; inspect the complete source in the Trigger run output).`;
+    }
+  }
+  const title = literalExcerpt(hit.title, Math.min(122, sectionLimit - link.length - 1));
+  const highlight = literalExcerpt(hit.highlight ?? "", Math.min(302, sectionLimit - link.length - title.length - 2));
+  return [title, link, highlight].filter(Boolean).join("\n");
+}
+
+/** Both the listener and the Trigger worker need their own configured environment. */
+export function requireResearchConfig(env: NodeJS.ProcessEnv): void {
+  for (const name of ["TRIGGER_SECRET_KEY", "EXA_API_KEY", "TRIGGER_PROJECT_REF"] as const) {
+    const value = env[name]?.trim();
+    if (!value || /replace|your[_-]|^<|\.\.\./i.test(value)) {
+      throw new Error(`Set ${name} to use durable Exa research.`);
+    }
+  }
+  if (!/^proj_[a-zA-Z0-9]+$/.test(env.TRIGGER_PROJECT_REF!.trim())) {
+    throw new Error("TRIGGER_PROJECT_REF must be the proj_ reference from your Trigger dashboard.");
+  }
+}
+
+/** Errors deliberately propagate so Trigger retries and records a failed run. */
+export async function executeResearch(payload: ResearchPayload, deps: {
+  waitForDecision: () => Promise<{ ok: false } | { ok: true; output: unknown }>;
+  search: (request: string) => Promise<unknown>;
+}) {
+  const input = researchPayloadSchema.parse(payload);
+  const decision = await deps.waitForDecision();
+  if (!decision.ok) return { status: "timed_out" as const };
+  const approved = approvalDecisionSchema.parse(decision.output);
+  if (!approved.approved) return { status: "declined" as const };
+  const result = await deps.search(input.request);
+  if (typeof result === "string") throw new Error(result);
+  return { status: "done" as const, findings: findingsSchema.parse(result) };
+}
+
+/**
+ * Delivery happens in a new, live Channels turn: managed MessageRefs cannot be
+ * reused across deliveries and Channels 0.9.2 has no public proactive-send API.
+ * The caller supplies that turn's post transport. Never return another
+ * conversation's results just because a model supplied a valid run ID.
+ */
+export async function reportResearch(runId: string, origin: ResearchOrigin, deps: {
+  retrieve: (id: string) => Promise<{ status: string; payload?: unknown; output?: unknown }>;
+  post: (text: string) => Promise<void>;
+}): Promise<string> {
+  const run = await deps.retrieve(runId);
+  const input = researchPayloadSchema.parse(run.payload);
+  const current = researchOriginSchema.parse(origin);
+  if (input.origin.platform !== current.platform ||
+      input.origin.channelCode !== current.channelCode ||
+      input.origin.conversationKey !== current.conversationKey) {
+    throw new Error("Research results can only be retrieved in their original conversation.");
+  }
+  const prefix = `Research ${runId}`;
+  let text: string;
+  if (run.status === "COMPLETED") {
+    const output = resultSchema.parse(run.output);
+    if (output.status === "done") {
+      await deps.post(`${prefix} completed. Exa references:${output.findings.length ? "" : " No results found for this request."}`);
+      for (const [index, hit] of output.findings.slice(0, 8).entries()) {
+        await deps.post(referenceMessage(hit, index));
+      }
+      return "Posted the research status and source references in this conversation; any unusable URLs are explicitly marked.";
+    } else {
+      text = `${prefix}: ${output.status === "declined" ? "approval declined" : "approval timed out"}. No search ran.`;
+    }
+  } else {
+    // Do not expose raw provider errors (which may include sensitive details).
+    text = `${prefix}: ${run.status}. ${["FAILED", "CRASHED", "CANCELED", "SYSTEM_FAILURE", "EXPIRED", "TIMED_OUT"].includes(run.status)
+      ? "Research did not complete. Inspect this run in your Trigger dashboard before retrying."
+      : "Ask me to check this run again later."}`;
+  }
+  await deps.post(text);
+  return "Posted the research status and any sources in this conversation.";
+}

--- a/apps/durable/src/trigger/deep-work.ts
+++ b/apps/durable/src/trigger/deep-work.ts
@@ -1,70 +1,20 @@
-/**
- * Durable work that outlives the chat turn.
- *
- * This is the piece a Channels listener genuinely cannot do on its own. A Slack
- * turn is a request/response cycle; anything that takes ten minutes, survives a
- * restart, or needs to retry belongs here instead.
- *
- * The shape is: pause on a waitpoint until a human approves, then work.
- *
- *   channel tool  →  wait.createToken()  →  triggers this task
- *                 →  posts an approval card in Slack
- *   human taps    →  wait.completeToken()
- *   this task     →  wait.forToken() resolves  →  does the long thing
- *
- * That inverts the usual demo: instead of the chat turn blocking while work
- * happens, the work blocks while the human decides — and the thread stays live.
- */
-import { logger, task, wait } from "@trigger.dev/sdk";
+/** Approved Exa research runs in Trigger and can be retrieved from its original thread. */
+import { task, wait } from "@trigger.dev/sdk";
 import { searchWeb } from "agent-core";
+import { executeResearch, requireResearchConfig } from "../research";
+import type { ApprovalDecision, ResearchPayload } from "../research";
 
-export type ApprovalDecision = {
-  approved: boolean;
-  /** Who decided, for the audit trail. */
-  decidedBy?: string;
-};
-
-export type DeepWorkPayload = {
-  /** The waitpoint this run pauses on. */
-  tokenId: string;
-  /** What the user actually asked for. */
-  request: string;
-  /** Where to report back, so the result lands where the work started. */
-  origin: { platform: string; channelCode: string; threadRef?: string };
-};
+export type { ApprovalDecision } from "../research";
+export type DeepWorkPayload = ResearchPayload;
 
 export const deepWork = task({
   id: "deep-work",
-  // Generous, because the ceiling here is a human's attention span, not the model's.
   maxDuration: 1800,
   run: async (payload: DeepWorkPayload) => {
-    logger.info("waiting for approval", { tokenId: payload.tokenId });
-
-    const decision = await wait.forToken<ApprovalDecision>(payload.tokenId);
-
-    if (!decision.ok) {
-      // The token timed out. Say so plainly rather than proceeding.
-      logger.warn("approval timed out", { tokenId: payload.tokenId });
-      return { status: "timed_out" as const, request: payload.request };
-    }
-
-    if (!decision.output.approved) {
-      logger.info("approval declined", { by: decision.output.decidedBy });
-      return { status: "declined" as const, request: payload.request };
-    }
-
-    // ── the actual long work ─────────────────────────────────────────────────
-    // Replace this with whatever your project does. It is a research sweep here
-    // only because that is demoable without any extra credentials.
-    logger.info("approved — starting work", { by: decision.output.decidedBy });
-
-    const findings = await searchWeb({ query: payload.request, results: 8 });
-
-    return {
-      status: "done" as const,
-      request: payload.request,
-      decidedBy: decision.output.decidedBy,
-      findings,
-    };
+    requireResearchConfig(process.env);
+    return executeResearch(payload, {
+      waitForDecision: () => wait.forToken<ApprovalDecision>(payload.tokenId),
+      search: (request) => searchWeb({ query: request, results: 8 }),
+    });
   },
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,10 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 3100",
+    "dev": "node --env-file-if-exists=../../.env ../../node_modules/next/dist/bin/next dev --turbopack -p 3100",
     "build": "next build",
-    "start": "next start -p 3100",
-    "typecheck": "tsc --noEmit"
+    "start": "node --env-file-if-exists=../../.env ../../node_modules/next/dist/bin/next start -p 3100",
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test src/lib/incidents.test.ts src/components/streamed-cards.test.ts"
   },
   "dependencies": {
     "@copilotkit/react-core": "1.70.1",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,122 +1,565 @@
 :root {
-  --ground: #f4f2f6;
-  --surface: #ffffff;
-  --border: #e0dbe7;
-  --text: #1b1721;
-  --muted: #6e6779;
-  --accent: #c4145f;
-  color-scheme: light dark;
+  --ground: #dedee9;
+  --surface: rgba(255, 255, 255, 0.5);
+  --border: #dbdbe5;
+  --text: #010507;
+  --muted: #57575b;
+  --accent: #010507;
+  color-scheme: light;
 }
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --ground: #131019;
-    --surface: #1b1724;
-    --border: #2e2739;
-    --text: #eeebf2;
-    --muted: #948ca1;
-    --accent: #ff5c9b;
-  }
+* {
+  box-sizing: border-box;
 }
-
-* { box-sizing: border-box; }
-
 body {
   margin: 0;
   background: var(--ground);
   color: var(--text);
-  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  font-family: "Plus Jakarta Sans", system-ui, sans-serif;
+  font-size: 14px;
   line-height: 1.6;
 }
-
-/* ── page ──────────────────────────────────────────────────────────────── */
-.ck-page { max-width: 46rem; margin: 0 auto; padding: 4rem 1.5rem 6rem; }
+button,
+input {
+  font: inherit;
+}
+button {
+  cursor: pointer;
+}
+button:focus-visible,
+input:focus-visible,
+summary:focus-visible {
+  outline: 2px solid #010507;
+  outline-offset: 3px;
+}
+code,
+time {
+  font-family: "Spline Sans Mono", monospace;
+  font-size: 12px;
+}
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+.ck-workspace {
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  padding: 8px 8px 80px;
+}
+.ck-atmosphere {
+  pointer-events: none;
+}
+.ck-atmosphere i {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(103px);
+  z-index: 0;
+  width: 446px;
+  height: 446px;
+  background: rgba(255, 172, 77, 0.2);
+}
+.ck-atmosphere i:nth-child(1) {
+  left: 1040px;
+  top: 11px;
+}
+.ck-atmosphere i:nth-child(2) {
+  left: 1339px;
+  top: 625px;
+  width: 609px;
+  height: 609px;
+  background: #c9c9da;
+}
+.ck-atmosphere i:nth-child(3) {
+  left: 670px;
+  top: -365px;
+  width: 609px;
+  height: 609px;
+  background: #c9c9da;
+}
+.ck-atmosphere i:nth-child(4) {
+  left: 508px;
+  top: 702px;
+  width: 609px;
+  height: 609px;
+  background: #f3f3fc;
+}
+.ck-atmosphere i:nth-child(5) {
+  left: 128px;
+  top: 331px;
+  background: rgba(255, 243, 136, 0.3);
+}
+.ck-atmosphere i:nth-child(6) {
+  left: -205px;
+  top: 803px;
+}
+.ck-workspace-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  max-width: 1440px;
+  margin: auto;
+  padding: 24px 16px 32px;
+}
 .ck-eyebrow {
-  font-family: ui-monospace, monospace; font-size: .7rem; letter-spacing: .14em;
-  text-transform: uppercase; color: var(--accent); margin: 0 0 .75rem;
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 8px;
 }
-.ck-page h1 {
-  font-size: clamp(1.9rem, 4.5vw, 2.6rem); line-height: 1.1; letter-spacing: -.025em;
-  margin: 0 0 1rem; text-wrap: balance;
+.ck-workspace h1 {
+  font-size: 32px;
+  line-height: 36px;
+  font-weight: 300;
+  margin: 0;
 }
-.ck-dek { color: var(--muted); max-width: 42ch; margin: 0; }
-.ck-page code {
-  font-family: ui-monospace, monospace; font-size: .85em; background: var(--surface);
-  border: 1px solid var(--border); border-radius: 3px; padding: .08em .35em;
+.ck-workspace-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) 280px;
+  gap: 8px;
+  max-width: 1440px;
+  margin: auto;
+  align-items: start;
 }
-.ck-focus {
-  display: flex; align-items: center; gap: .75rem; margin: 2rem 0 0;
-  padding: .6rem .9rem; border: 1px solid var(--accent); border-radius: 3px;
-  background: var(--surface); font-size: .9rem;
+.ck-panel {
+  position: relative;
+  z-index: 1;
+  background: rgba(255, 255, 255, 0.5);
+  border: 2px solid #fff;
+  border-radius: 8px;
+  padding: 24px;
+  min-width: 0;
 }
-
-.ck-ladder { display: flex; flex-direction: column; margin: 3rem 0 0; }
-.ck-ladder article {
-  display: grid; grid-template-columns: 3.25rem minmax(0, 1fr); gap: 1.25rem;
-  padding: 1.4rem 0; border-top: 1px solid var(--border);
+.ck-incident-list {
+  padding: 16px;
 }
-.ck-ladder article:last-child { border-bottom: 1px solid var(--border); }
-.ck-ladder b {
-  font-size: 2rem; line-height: .85; letter-spacing: -.05em; color: var(--border);
-  font-variant-numeric: tabular-nums;
+.ck-section-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font:
+    400 10px "Spline Sans Mono",
+    monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+  margin: 0 0 16px;
 }
-.ck-ladder article:last-child b { color: var(--accent); }
-.ck-ladder h2 { font-size: 1.05rem; margin: 0 0 .35rem; }
-.ck-ladder p { margin: 0 0 .5rem; color: var(--muted); }
-.ck-test { border-left: 2px solid var(--border); padding-left: .75rem; font-size: .9rem; }
-
-.ck-try { margin-top: 3rem; }
-.ck-try h2 { font-size: 1.05rem; margin: 0 0 .75rem; }
-.ck-try ul { margin: 0; padding-left: 1.1rem; color: var(--muted); }
-.ck-try li { margin-bottom: .4rem; }
+.ck-section-label > span:not(.ck-tag) {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.ck-muted {
+  color: var(--muted);
+  font-size: 12px;
+}
+.ck-incident {
+  text-align: left;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  border-radius: 4px;
+  padding: 12px;
+  margin-bottom: 4px;
+  color: var(--text);
+}
+.ck-incident:hover {
+  background: rgba(255, 255, 255, 0.5);
+}
+.ck-incident[aria-pressed="true"] {
+  background: rgba(255, 255, 255, 0.7);
+}
+.ck-incident strong {
+  display: block;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 1.25;
+  margin: 12px 0 8px;
+}
+.ck-incident-meta {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--muted);
+}
+.ck-tag {
+  display: inline-block;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.4;
+  padding: 2px 6px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--text);
+  white-space: nowrap;
+}
+.ck-incident[aria-pressed="true"] .ck-tag {
+  background: #010507;
+  color: white;
+}
+.ck-context-note {
+  margin-top: 32px;
+  font-size: 12px;
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+.ck-context-note p {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+.ck-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #189370;
+  margin-right: 4px;
+}
+.ck-incident-body {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+.ck-detail h2 {
+  margin: 24px 0 12px;
+  font-size: 24px;
+  font-weight: 500;
+  line-height: 28px;
+}
+.ck-detail > p {
+  color: var(--muted);
+}
+.ck-detail-facts {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin: 24px 0;
+}
+.ck-detail-facts dt {
+  color: var(--muted);
+  font-size: 12px;
+}
+.ck-detail-facts dd {
+  margin: 4px 0 0;
+}
+.ck-impact {
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+.ck-impact h3 {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+.ck-impact p {
+  margin: 0;
+  font-size: 14px;
+}
+.ck-timeline {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.ck-timeline li {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  gap: 16px;
+  padding-bottom: 20px;
+}
+.ck-timeline li:last-child {
+  padding-bottom: 0;
+}
+.ck-timeline time {
+  color: var(--muted);
+  padding-top: 2px;
+}
+.ck-timeline strong {
+  font-size: 12px;
+  font-weight: 600;
+}
+.ck-timeline p {
+  margin: 4px 0 0;
+  color: var(--muted);
+}
+.ck-task-list {
+  list-style: none;
+  padding: 0;
+}
+.ck-task-list li {
+  display: flex;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+  overflow-wrap: anywhere;
+}
+.ck-empty {
+  padding: 16px 0;
+  color: var(--muted);
+}
+.ck-task-form label {
+  display: block;
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+.ck-task-form > div {
+  display: flex;
+  gap: 8px;
+}
+.ck-task-form input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: 4px;
+  padding: 8px 12px;
+  color: var(--text);
+}
+.ck-task-form button {
+  white-space: nowrap;
+}
+.ck-notice {
+  min-height: 16px;
+  font-size: 12px;
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+.ck-guide h3 {
+  font-size: 20px;
+  line-height: 24px;
+  font-weight: 500;
+}
+.ck-guide ol {
+  padding: 0;
+  list-style: none;
+  counter-reset: prompts;
+}
+.ck-guide li {
+  padding: 16px 0;
+  border-bottom: 1px solid var(--border);
+  counter-increment: prompts;
+}
+.ck-guide li strong {
+  font-weight: 500;
+}
+.ck-guide li strong::before {
+  content: "0" counter(prompts) " / ";
+  font:
+    12px "Spline Sans Mono",
+    monospace;
+  color: var(--muted);
+}
+.ck-guide li p {
+  margin: 8px 0;
+  font-size: 12px;
+}
+.ck-guide li code {
+  color: var(--muted);
+  font-size: 10px;
+}
+.ck-guide details {
+  font-size: 12px;
+}
+.ck-guide summary {
+  cursor: pointer;
+}
+.ck-guide details p {
+  margin: 12px 0;
+}
+.ck-guide-footer {
+  color: var(--muted);
+  font-size: 12px;
+  margin: 24px 0 0;
+}
+/* Shared voice surface and agent cards. */
+.ck-page {
+  max-width: 46rem;
+  margin: auto;
+  padding: 48px 24px;
+}
+.ck-dek {
+  color: var(--muted);
+}
+@media (max-width: 1100px) {
+  .ck-workspace-grid {
+    grid-template-columns: 220px minmax(0, 1fr);
+  }
+  .ck-guide {
+    grid-column: 1 / -1;
+  }
+  .ck-guide ol {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0 24px;
+  }
+}
+@media (max-width: 640px) {
+  .ck-workspace-header {
+    padding: 24px 8px;
+  }
+  .ck-workspace-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .ck-panel {
+    padding: 16px;
+  }
+  .ck-incident-list .ck-context-note {
+    margin-top: 16px;
+  }
+  .ck-detail-facts {
+    grid-template-columns: 1fr;
+    gap: 12px;
+  }
+  .ck-guide ol {
+    display: block;
+  }
+  .ck-timeline li {
+    grid-template-columns: 72px minmax(0, 1fr);
+    gap: 12px;
+  }
+  .ck-timeline time {
+    font-size: 10px;
+  }
+  .ck-task-form > div {
+    flex-wrap: wrap;
+  }
+}
 
 /* ── agent-rendered cards ──────────────────────────────────────────────── */
 .ck-card {
-  background: var(--surface); border: 1px solid var(--border);
-  border-left: 3px solid var(--muted); border-radius: 3px;
-  padding: .9rem 1rem; margin: .5rem 0; font-size: .92rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--muted);
+  border-radius: 3px;
+  padding: 0.9rem 1rem;
+  margin: 0.5rem 0;
+  font-size: 0.92rem;
 }
-.ck-card--gate { border-left-color: var(--accent); }
-.ck-card h3 { margin: 0 0 .4rem; font-size: .98rem; }
-.ck-card p { margin: 0 0 .5rem; color: var(--muted); }
-.ck-card p:last-child { margin-bottom: 0; }
-.ck-gate-done { font-style: italic; }
+.ck-card--gate {
+  border-left-color: var(--accent);
+}
+.ck-card h3 {
+  margin: 0 0 0.4rem;
+  font-size: 0.98rem;
+}
+.ck-card p {
+  margin: 0 0 0.5rem;
+  color: var(--muted);
+}
+.ck-card p:last-child {
+  margin-bottom: 0;
+}
+.ck-gate-done {
+  font-style: italic;
+}
 
-.ck-facts { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .6rem; margin: .6rem 0 0; }
+.ck-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+  margin: 0.6rem 0 0;
+}
 .ck-facts dt {
-  font-family: ui-monospace, monospace; font-size: .65rem; letter-spacing: .1em;
-  text-transform: uppercase; color: var(--muted);
+  font-family: ui-monospace, monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
-.ck-facts dd { margin: .1rem 0 0; }
-.ck-steps { margin: .6rem 0 0; padding-left: 1.1rem; color: var(--muted); }
+.ck-facts dd {
+  margin: 0.1rem 0 0;
+}
+.ck-steps {
+  margin: 0.6rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--muted);
+}
 
-.ck-scroll { overflow-x: auto; }
-.ck-card table { border-collapse: collapse; width: 100%; font-size: .87rem; }
-.ck-card th, .ck-card td { text-align: left; padding: .4rem .6rem; border-bottom: 1px solid var(--border); }
+.ck-scroll {
+  overflow-x: auto;
+}
+.ck-card table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.87rem;
+}
+.ck-card th,
+.ck-card td {
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--border);
+}
 .ck-card th {
-  font-family: ui-monospace, monospace; font-size: .65rem; letter-spacing: .09em;
-  text-transform: uppercase; color: var(--muted); font-weight: 500;
+  font-family: ui-monospace, monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-weight: 500;
 }
 
-.ck-actions { display: flex; gap: .5rem; margin-top: .75rem; }
-.ck-btn {
-  font: inherit; font-size: .85rem; padding: .35rem .8rem; cursor: pointer;
-  background: var(--surface); color: var(--text);
-  border: 1px solid var(--border); border-radius: 3px;
+.ck-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
 }
-.ck-btn:hover { border-color: var(--muted); }
-.ck-btn--primary { background: var(--accent); border-color: var(--accent); color: #fff; }
-.ck-btn--tiny { font-size: .75rem; padding: .15rem .5rem; }
-.ck-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.ck-btn {
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.35rem 0.8rem;
+  cursor: pointer;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+}
+.ck-btn:hover {
+  border-color: var(--muted);
+}
+.ck-btn--primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+.ck-btn--tiny {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+}
+.ck-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 
 .ck-status {
-  align-self: center; font-family: ui-monospace, monospace; font-size: .7rem;
-  letter-spacing: .1em; text-transform: uppercase; color: var(--muted);
+  align-self: center;
+  font-family: ui-monospace, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
-.ck-status[data-status="live"] { color: #2e7d5b; }
-.ck-status[data-status="error"] { color: var(--accent); }
+.ck-status[data-status="live"] {
+  color: #2e7d5b;
+}
+.ck-status[data-status="error"] {
+  color: var(--accent);
+}
 .ck-transcript {
-  font-family: ui-monospace, monospace; font-size: .8rem; line-height: 1.8;
-  background: var(--surface); border: 1px solid var(--border); border-radius: 3px;
-  padding: .9rem 1rem; overflow-x: auto; white-space: pre-wrap;
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+  line-height: 1.8;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,12 +5,23 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Agents, Everywhere — web surface",
-  description: "The same agent, on the web, rendering its own UI.",
+  description:
+    "An incident workspace with shared context, native agent UI, and local follow-ups.",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
     <html lang="en">
+      <head>
+        <link
+          href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&family=Spline+Sans+Mono:wght@400;500;600&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body>
         <Providers>{children}</Providers>
       </body>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,83 +1,259 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState, type FormEvent } from "react";
 import { CopilotSidebar } from "@copilotkit/react-core/v2";
 import { GenerativeUI } from "@/components/generative-ui";
 import { AppControl } from "@/components/app-control";
-
-const LADDER = [
-  {
-    rung: "01",
-    name: "Reachable",
-    body: "The agent is addressable where you already are. Mention it, it answers.",
-    test: "Table stakes. Every submission clears this.",
-  },
-  {
-    rung: "02",
-    name: "Situated",
-    body: "It reads the surface without being told — what the page is showing, who is asking, what happened before.",
-    test: "Delete the context and ask again. Same answer? Still rung 01.",
-  },
-  {
-    rung: "03",
-    name: "Native",
-    body: "It renders and acts in the surface's own idioms, and its side effects land where the work lives.",
-    test: "Does it belong, or is it a chat window in a costume?",
-  },
-];
+import {
+  createFollowup,
+  findIncident,
+  incidents,
+  workspaceContext,
+  type Followup,
+} from "@/lib/incidents";
 
 export default function Home() {
-  const [focus, setFocus] = useState("");
+  const [selectedId, setSelectedId] = useState<string>(incidents[0].id);
+  const [followups, setFollowups] = useState<Followup[]>([]);
+  const [title, setTitle] = useState("");
+  const [notice, setNotice] = useState("");
+  const { selectedIncident: incident, followups: visibleTasks } =
+    workspaceContext(selectedId, followups);
+  const selectIncident = useCallback((id: string) => {
+    setSelectedId(findIncident(id).id);
+    setTitle("");
+    setNotice("");
+  }, []);
+  const addFollowup = useCallback((incidentId: string, nextTitle: string) => {
+    const task = createFollowup(incidentId, nextTitle, crypto.randomUUID());
+    setFollowups((current) => [...current, task]);
+    setNotice(`Added a local follow-up to ${task.incidentId}.`);
+    return task;
+  }, []);
+  function submitFollowup(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    try {
+      addFollowup(selectedId, title);
+      setTitle("");
+    } catch (error) {
+      setNotice(
+        error instanceof Error ? error.message : "Unable to add follow-up.",
+      );
+    }
+  }
 
   return (
     <>
       <GenerativeUI />
-      <AppControl focus={focus} setFocus={setFocus} />
-
-      <main className="ck-page">
-        <header>
-          <p className="ck-eyebrow">On the web</p>
-          <h1>The same agent, rendering its own UI.</h1>
-          <p className="ck-dek">
-            This page runs the identical agent as <code>apps/channel-slack</code> and{" "}
-            <code>apps/local-chat</code>. Nothing about it was rewritten for the web — only the
-            binding changed. Ask it something in the sidebar and watch it choose a component.
-          </p>
-        </header>
-
-        {focus && (
-          <p className="ck-focus">
-            Focused on <strong>{focus}</strong>
-            <button type="button" className="ck-btn ck-btn--tiny" onClick={() => setFocus("")}>
-              clear
-            </button>
-          </p>
-        )}
-
-        <section className="ck-ladder">
-          {LADDER.map((level) => (
-            <article key={level.rung}>
-              <b>{level.rung}</b>
-              <div>
-                <h2>{level.name}</h2>
-                <p>{level.body}</p>
-                <p className="ck-test">{level.test}</p>
-              </div>
-            </article>
+      <AppControl
+        selectedId={selectedId}
+        followups={followups}
+        selectIncident={selectIncident}
+        addFollowup={addFollowup}
+      />
+      <main className="ck-workspace">
+        <div className="ck-atmosphere" aria-hidden="true">
+          {Array.from({ length: 6 }, (_, i) => (
+            <i key={i} />
           ))}
-        </section>
-
-        <section className="ck-try">
-          <h2>Try</h2>
-          <ul>
-            <li>&ldquo;Summarise the context ladder as a card&rdquo; — calls <code>brief_card</code></li>
-            <li>&ldquo;Compare the three rungs in a table&rdquo; — calls <code>comparison_table</code></li>
-            <li>&ldquo;Focus the page on voice agents&rdquo; — calls <code>set_focus</code>, and the page changes</li>
-            <li>&ldquo;Delete my account&rdquo; — calls <code>confirm_action</code> and stops for approval</li>
-          </ul>
-        </section>
+        </div>
+        <header className="ck-workspace-header">
+          <div>
+            <p className="ck-eyebrow">Agents, everywhere / Web workspace</p>
+            <h1>Incident room</h1>
+          </div>
+          <span className="ck-tag">Sample data</span>
+        </header>
+        <div className="ck-workspace-grid">
+          <aside
+            className="ck-panel ck-incident-list"
+            aria-label="Incident selection"
+          >
+            <h2 className="ck-section-label">
+              Incidents <span />
+            </h2>
+            <p className="ck-muted">
+              Pick an incident. Your agent sees the same context you do.
+            </p>
+            {incidents.map((item) => (
+              <button
+                type="button"
+                className="ck-incident"
+                aria-pressed={selectedId === item.id}
+                key={item.id}
+                onClick={() => selectIncident(item.id)}
+              >
+                <span className="ck-incident-meta">
+                  <code>{item.id}</code>
+                  <span className="ck-tag">{item.severity}</span>
+                </span>
+                <strong>{item.title}</strong>
+                <span className="ck-muted">
+                  {item.status} · {item.service}
+                </span>
+              </button>
+            ))}
+            <div className="ck-context-note">
+              <span className="ck-dot" /> Context follows your selection
+              <p>
+                The selected incident, timeline, and follow-ups are shared with
+                the agent automatically.
+              </p>
+            </div>
+          </aside>
+          <div className="ck-incident-body">
+            <section
+              className="ck-panel ck-detail"
+              aria-labelledby="incident-title"
+            >
+              <div className="ck-incident-meta">
+                <code>
+                  {incident.id} · {incident.channel}
+                </code>
+                <span className="ck-tag">{incident.status}</span>
+              </div>
+              <h2 id="incident-title">{incident.title}</h2>
+              <p>{incident.summary}</p>
+              <dl className="ck-detail-facts">
+                <div>
+                  <dt>Service</dt>
+                  <dd>{incident.service}</dd>
+                </div>
+                <div>
+                  <dt>Incident lead</dt>
+                  <dd>{incident.owner}</dd>
+                </div>
+                <div>
+                  <dt>Last update</dt>
+                  <dd>{incident.updated}</dd>
+                </div>
+              </dl>
+              <div className="ck-impact">
+                <h3>Observed impact</h3>
+                <p>{incident.impact}</p>
+              </div>
+            </section>
+            <section className="ck-panel" aria-labelledby="timeline-title">
+              <h2 className="ck-section-label" id="timeline-title">
+                Timeline <span />
+              </h2>
+              <ol className="ck-timeline">
+                {incident.timeline.map((event) => (
+                  <li key={event.time}>
+                    <time>{event.time} UTC</time>
+                    <div>
+                      <strong>{event.author}</strong>
+                      <p>{event.detail}</p>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </section>
+            <section className="ck-panel" aria-labelledby="followup-title">
+              <h2 className="ck-section-label" id="followup-title">
+                Follow-ups <span />
+                <span className="ck-tag">{visibleTasks.length} local</span>
+              </h2>
+              <p className="ck-muted">
+                This page session only. Refreshing clears tasks; no external
+                system is updated.
+              </p>
+              {visibleTasks.length ? (
+                <ul className="ck-task-list">
+                  {visibleTasks.map((task) => (
+                    <li key={task.id}>
+                      <span aria-hidden="true">○</span>
+                      {task.title}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="ck-empty">
+                  No follow-ups yet. Add one here or ask the agent.
+                </p>
+              )}
+              <form onSubmit={submitFollowup} className="ck-task-form">
+                <label htmlFor="task-title">
+                  New follow-up for {incident.id}
+                </label>
+                <div>
+                  <input
+                    id="task-title"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    maxLength={200}
+                    placeholder="e.g. Compare connection pool metrics"
+                    required
+                  />
+                  <button className="ck-btn ck-btn--primary" type="submit">
+                    Add task
+                  </button>
+                </div>
+              </form>
+              <p role="status" className="ck-notice">
+                {notice}
+              </p>
+            </section>
+          </div>
+          <aside className="ck-panel ck-guide" aria-label="Agent demo prompts">
+            <h2 className="ck-section-label">
+              Put context to work <span />
+            </h2>
+            <h3>Bring the agent into the room.</h3>
+            <p className="ck-muted">
+              Open the chat to try these prompts with your configured model
+              provider.
+            </p>
+            <ol>
+              <li>
+                <strong>Read the room</strong>
+                <p>
+                  “Show an incident card for the selected incident, using what
+                  you can see.”
+                </p>
+                <code>incident_card</code>
+              </li>
+              <li>
+                <strong>Connect the events</strong>
+                <p>
+                  “Draw a timeline and separate observations from possible
+                  causes.”
+                </p>
+                <code>timeline</code>
+              </li>
+              <li>
+                <strong>Take a local action</strong>
+                <p>“Add a follow-up to check the metrics for this incident.”</p>
+                <code>create_followup</code>
+              </li>
+              <li>
+                <strong>Move with the work</strong>
+                <p>
+                  “Switch to{" "}
+                  {selectedId === "INC-1042" ? "INC-1043" : "INC-1042"} and
+                  summarize what changed.”
+                </p>
+                <code>select_incident</code>
+              </li>
+            </ol>
+            <details>
+              <summary>Try an approval card</summary>
+              <p>
+                “Use propose_action to ask me to approve a sample rollback. Do
+                not execute it.”
+              </p>
+              <p>
+                An approval card records a decision. This workspace has no
+                production rollback tool.
+              </p>
+            </details>
+            <p className="ck-guide-footer">
+              You can select incidents and add local tasks without API
+              credentials.
+            </p>
+          </aside>
+        </div>
       </main>
-
       <CopilotSidebar />
     </>
   );

--- a/apps/web/src/components/app-control.tsx
+++ b/apps/web/src/components/app-control.tsx
@@ -1,44 +1,56 @@
 "use client";
 
-/**
- * In-app actions — rung 3 on the web.
- *
- * A frontend tool lets the agent *operate the app*, not just talk about it.
- * This is the web equivalent of a Slack agent posting a Block Kit card: the
- * side effect lands in the surface the person is already looking at.
- */
 import { useFrontendTool, useAgentContext } from "@copilotkit/react-core/v2";
 import { z } from "zod";
+import { findIncident, workspaceContext, type Followup } from "@/lib/incidents";
 
 export function AppControl({
-  focus,
-  setFocus,
+  selectedId,
+  followups,
+  selectIncident,
+  addFollowup,
 }: {
-  focus: string;
-  setFocus: (next: string) => void;
+  selectedId: string;
+  followups: Followup[];
+  selectIncident: (id: string) => void;
+  addFollowup: (incidentId: string, title: string) => Followup;
 }) {
-  // Ambient context: the agent knows what the page is showing without being
-  // told. This is what moves it from "reachable" to "situated".
   useAgentContext({
-    description: "What the page is currently focused on",
-    value: focus || "nothing yet",
+    description:
+      "The incident workspace currently visible to the user, including sample timeline and local follow-ups. Use this context without asking the user to paste it. Never describe sample observations as live production data.",
+    value: workspaceContext(selectedId, followups),
   });
 
   useFrontendTool(
     {
-      name: "set_focus",
+      name: "select_incident",
       description:
-        "Change what the page is focused on. Use it when the user asks to look at, filter to, or jump to something.",
-      parameters: z.object({
-        focus: z.string().describe("The surface, topic, or filter to focus the page on."),
-      }),
-      handler: async ({ focus: next }) => {
-        setFocus(next);
-        return `The page is now focused on ${next}.`;
+        "Open an existing sample incident in the workspace. Use an ID from availableIncidents.",
+      parameters: z.object({ incidentId: z.string() }),
+      handler: async ({ incidentId }) => {
+        const incident = findIncident(incidentId);
+        selectIncident(incident.id);
+        return `Opened ${incident.id}: ${incident.title}. The visible details and agent context now show this incident.`;
       },
     },
-    [setFocus],
+    [selectIncident],
   );
 
+  useFrontendTool(
+    {
+      name: "create_followup",
+      description:
+        "Add a follow-up task for a known incident in this browser page session only. Does not create a workplace task, send a notification, or change production. Use the selected incident unless the user specifies another.",
+      parameters: z.object({
+        incidentId: z.string(),
+        title: z.string().trim().min(1).max(200),
+      }),
+      handler: async ({ incidentId, title }) => {
+        const task = addFollowup(incidentId, title);
+        return `Added local follow-up ${task.id} to ${task.incidentId}: ${task.title}. It is visible under that incident and will be cleared on refresh; no external system was updated.`;
+      },
+    },
+    [addFollowup],
+  );
   return null;
 }

--- a/apps/web/src/components/generative-ui.tsx
+++ b/apps/web/src/components/generative-ui.tsx
@@ -11,12 +11,12 @@
  * with `defineChannelComponent`. Same agent, same intent, native rendering on
  * each surface — which is the whole claim this kit is making.
  *
- * The render function receives the schema output directly as props.
+ * Renderers receive streamed partial arguments before schema defaults apply.
  */
 import { useComponent, useHumanInTheLoop } from "@copilotkit/react-core/v2";
 import { z } from "zod";
 
-const toneColor = { neutral: "var(--muted)", good: "#2e7d5b", attention: "var(--accent)" } as const;
+import { IncidentCard, Timeline } from "./streamed-cards";
 
 export function GenerativeUI() {
   useComponent({
@@ -30,29 +30,7 @@ export function GenerativeUI() {
       nextSteps: z.array(z.string()).max(3).default([]),
       tone: z.enum(["neutral", "good", "attention"]).default("neutral"),
     }),
-    render: ({ headline, summary, facts, nextSteps, tone }) => (
-      <article className="ck-card" style={{ borderLeftColor: toneColor[tone] }}>
-        <h3>{headline}</h3>
-        <p>{summary}</p>
-        {facts.length > 0 && (
-          <dl className="ck-facts">
-            {facts.map((fact) => (
-              <div key={fact.label}>
-                <dt>{fact.label}</dt>
-                <dd>{fact.value}</dd>
-              </div>
-            ))}
-          </dl>
-        )}
-        {nextSteps.length > 0 && (
-          <ul className="ck-steps">
-            {nextSteps.map((step) => (
-              <li key={step}>{step}</li>
-            ))}
-          </ul>
-        )}
-      </article>
-    ),
+    render: IncidentCard,
   });
 
   useComponent({
@@ -64,31 +42,7 @@ export function GenerativeUI() {
       columns: z.array(z.string()).min(1).max(4),
       rows: z.array(z.array(z.string())),
     }),
-    render: ({ title, columns, rows }) => (
-      <article className="ck-card">
-        {title && <h3>{title}</h3>}
-        <div className="ck-scroll">
-          <table>
-            <thead>
-              <tr>
-                {columns.map((header) => (
-                  <th key={header}>{header}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row, rowIndex) => (
-                <tr key={rowIndex}>
-                  {row.map((cell, cellIndex) => (
-                    <td key={cellIndex}>{cell}</td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </article>
-    ),
+    render: Timeline,
   });
 
   /**

--- a/apps/web/src/components/streamed-cards.test.ts
+++ b/apps/web/src/components/streamed-cards.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { IncidentCard, Timeline } from "./streamed-cards";
+
+test("incident card renders loading content before any arguments arrive", () => {
+  const html = renderToStaticMarkup(createElement(IncidentCard, {}));
+  assert.match(html, /Preparing incident assessment/);
+});
+
+test("incident card preserves the headline while other fields are streaming", () => {
+  const html = renderToStaticMarkup(createElement(IncidentCard, { headline: "Checkout unavailable" }));
+  assert.match(html, /Checkout unavailable/);
+  assert.match(html, /Gathering incident details/);
+});
+
+test("incident card tolerates partial arrays and nested entries", () => {
+  const html = renderToStaticMarkup(createElement(IncidentCard, {
+    tone: "att",
+    facts: [null, {}, { label: "Impact" }, { label: "Since", value: "10:00" }],
+    nextSteps: [null, "Check deployment"],
+  }));
+  assert.match(html, /var\(--muted\)/);
+  assert.match(html, /Impact/);
+  assert.match(html, /10:00/);
+  assert.match(html, /Check deployment/);
+  assert.match(html, /Loading/);
+});
+
+test("timeline renders loading content for empty and title-only arguments", () => {
+  assert.match(renderToStaticMarkup(createElement(Timeline, {})), /Preparing timeline/);
+  const html = renderToStaticMarkup(createElement(Timeline, { title: "Incident history" }));
+  assert.match(html, /Incident history/);
+  assert.match(html, /Preparing timeline/);
+  assert.match(renderToStaticMarkup(createElement(Timeline, { columns: ["Time"] })), /Loading events/);
+  assert.match(renderToStaticMarkup(createElement(Timeline, { rows: [["10:00"]] })), /Preparing timeline/);
+  assert.match(renderToStaticMarkup(createElement(Timeline, { columns: null, rows: null })), /Preparing timeline/);
+});
+
+test("timeline tolerates partially streamed columns, rows, and cells", () => {
+  const html = renderToStaticMarkup(createElement(Timeline, {
+    columns: ["Time", null],
+    rows: [null, [], ["10:00"], ["10:05", null]],
+  }));
+  assert.match(html, /Time/);
+  assert.match(html, /10:00/);
+  assert.match(html, /10:05/);
+  assert.match(html, /Loading/);
+});
+
+test("complete incident and timeline arguments render their content", () => {
+  const card = renderToStaticMarkup(createElement(IncidentCard, {
+    headline: "Checkout restored", summary: "All customers can check out",
+    facts: [{ label: "Errors", value: "0%" }], nextSteps: ["Monitor"], tone: "good",
+  }));
+  for (const text of ["Checkout restored", "All customers can check out", "Errors", "0%", "Monitor", "#2e7d5b"]) {
+    assert.ok(card.includes(text));
+  }
+  assert.doesNotMatch(card, /Loading|Preparing|Gathering/);
+  const timeline = renderToStaticMarkup(createElement(Timeline, {
+    title: "Recovery", columns: ["Time", "Event"], rows: [["10:00", "Deployed"], ["10:10", "Recovered"]],
+  }));
+  for (const text of ["Recovery", "Time", "Event", "10:00", "Deployed", "10:10", "Recovered"]) {
+    assert.ok(timeline.includes(text));
+  }
+  assert.doesNotMatch(timeline, /Loading|Preparing/);
+});

--- a/apps/web/src/components/streamed-cards.tsx
+++ b/apps/web/src/components/streamed-cards.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+
+// Tool arguments arrive incrementally, before schema defaults are applied.
+export interface IncidentCardProps {
+  headline?: string;
+  summary?: string;
+  facts?: Array<{ label?: string; value?: string } | null> | null;
+  nextSteps?: Array<string | null> | null;
+  tone?: string;
+}
+
+export interface TimelineProps {
+  title?: string;
+  columns?: Array<string | null> | null;
+  rows?: Array<Array<string | null> | null> | null;
+}
+
+const toneColor = { neutral: "var(--muted)", good: "#2e7d5b", attention: "var(--accent)" } as const;
+
+export function IncidentCard({ headline, summary, facts, nextSteps, tone }: IncidentCardProps) {
+  const color = tone === "good" || tone === "attention" ? toneColor[tone] : toneColor.neutral;
+  return (
+    <article className="ck-card" style={{ borderLeftColor: color }}>
+      <h3>{headline || "Preparing incident assessment…"}</h3>
+      <p>{summary || "Gathering incident details…"}</p>
+      {!!facts?.length && (
+        <dl className="ck-facts">
+          {facts.map((fact, index) => (
+            <div key={index}>
+              <dt>{fact?.label || "Loading…"}</dt>
+              <dd>{fact?.value || "Loading…"}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {!!nextSteps?.length && (
+        <ul className="ck-steps">
+          {nextSteps.map((step, index) => (
+            <li key={index}>{step || "Loading…"}</li>
+          ))}
+        </ul>
+      )}
+    </article>
+  );
+}
+
+export function Timeline({ title, columns, rows }: TimelineProps) {
+  return (
+    <article className="ck-card">
+      {title && <h3>{title}</h3>}
+      {!columns?.length ? (
+        <p>Preparing timeline…</p>
+      ) : (
+        <div className="ck-scroll">
+          <table>
+            <thead>
+              <tr>
+                {columns.map((header, index) => (
+                  <th key={index}>{header || "Loading…"}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {!rows?.length ? (
+                <tr><td colSpan={columns.length}>Loading events…</td></tr>
+              ) : rows.map((row, rowIndex) => (
+                <tr key={rowIndex}>
+                  {columns.map((_, cellIndex) => (
+                    <td key={cellIndex}>{row?.[cellIndex] ?? "Loading…"}</td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/apps/web/src/lib/incidents.test.ts
+++ b/apps/web/src/lib/incidents.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createFollowup, findIncident, workspaceContext } from "./incidents";
+
+test("selection changes the shared incident and timeline together", () => {
+  const checkout = workspaceContext("INC-1042", []);
+  const notifications = workspaceContext("INC-1043", []);
+  assert.equal(checkout.selectedIncident.service, "Checkout API");
+  assert.equal(notifications.selectedIncident.service, "Notifications");
+  assert.match(notifications.selectedIncident.timeline[0].detail, /emails/);
+  assert.equal(notifications.availableIncidents.length, 2);
+});
+
+test("follow-ups are trimmed and scoped to their incident when switching", () => {
+  const tasks = [
+    createFollowup("INC-1042", "  Check pool metrics  ", "task-1"),
+    createFollowup("INC-1043", "Watch queue", "task-2"),
+  ];
+  assert.equal(tasks[0].title, "Check pool metrics");
+  assert.deepEqual(workspaceContext("INC-1042", tasks).followups, [tasks[0]]);
+  assert.deepEqual(workspaceContext("INC-1043", tasks).followups, [tasks[1]]);
+  assert.equal(tasks.length, 2);
+});
+
+test("unknown incidents and empty or oversized follow-ups are rejected", () => {
+  assert.throws(() => findIncident("unknown"), /Unknown incident/);
+  assert.throws(
+    () => createFollowup("unknown", "Task", "1"),
+    /Unknown incident/,
+  );
+  assert.throws(() => createFollowup("INC-1042", " \n ", "1"), /title/);
+  assert.throws(() => createFollowup("INC-1042", "x".repeat(201), "1"), /200/);
+  assert.match(
+    workspaceContext("INC-1042", []).dataSource,
+    /No external task system/,
+  );
+});

--- a/apps/web/src/lib/incidents.ts
+++ b/apps/web/src/lib/incidents.ts
@@ -1,0 +1,113 @@
+/** Sample workspace data. All follow-ups live only in the current React session. */
+export const incidents = [
+  {
+    id: "INC-1042",
+    title: "Checkout latency after deploy",
+    severity: "SEV 2",
+    status: "Investigating",
+    service: "Checkout API",
+    owner: "Maya Chen",
+    channel: "#inc-checkout",
+    updated: "09:24 UTC",
+    summary:
+      "Customers are waiting longer to complete checkout. Latency rose after the latest deployment; no confirmed root cause yet.",
+    impact:
+      "P95 latency is 4.8s, up from 420ms. Approximately 18% of checkout requests are affected.",
+    timeline: [
+      {
+        time: "09:12",
+        author: "Deploy bot",
+        detail: "Checkout v2.18 deployed to production.",
+      },
+      {
+        time: "09:17",
+        author: "Monitor",
+        detail: "P95 latency crossed the 2s alert threshold.",
+      },
+      {
+        time: "09:24",
+        author: "Maya Chen",
+        detail:
+          "Investigating connection pool saturation. Rollback is an option, not yet approved.",
+      },
+    ],
+  },
+  {
+    id: "INC-1043",
+    title: "Delayed notification delivery",
+    severity: "SEV 3",
+    status: "Monitoring",
+    service: "Notifications",
+    owner: "Alex Rivera",
+    channel: "#inc-notifications",
+    updated: "09:31 UTC",
+    summary:
+      "Email notifications are arriving late. Additional workers are draining the queue and delivery times are improving.",
+    impact:
+      "A backlog of 2,400 messages remains. No messages have been lost in this sample scenario.",
+    timeline: [
+      {
+        time: "09:05",
+        author: "Support",
+        detail: "Customers report delayed confirmation emails.",
+      },
+      {
+        time: "09:19",
+        author: "Alex Rivera",
+        detail: "Added two queue workers after identifying a traffic spike.",
+      },
+      {
+        time: "09:31",
+        author: "Monitor",
+        detail: "Oldest message age fell from 14 minutes to 3 minutes.",
+      },
+    ],
+  },
+] as const;
+
+export type Incident = (typeof incidents)[number];
+export type Followup = {
+  id: string;
+  incidentId: Incident["id"];
+  title: string;
+};
+
+export function findIncident(id: string): Incident {
+  const incident = incidents.find((item) => item.id === id);
+  if (!incident)
+    throw new Error(
+      `Unknown incident ${id}. Choose ${incidents.map((item) => item.id).join(" or ")}.`,
+    );
+  return incident;
+}
+
+export function createFollowup(
+  incidentId: string,
+  title: string,
+  id: string,
+): Followup {
+  const incident = findIncident(incidentId);
+  const trimmed = title.trim();
+  if (!trimmed)
+    throw new Error("Enter a follow-up title before adding a task.");
+  if (trimmed.length > 200)
+    throw new Error("Keep the follow-up title to 200 characters or fewer.");
+  return { id, incidentId: incident.id, title: trimmed };
+}
+
+export function workspaceContext(selectedId: string, followups: Followup[]) {
+  return {
+    dataSource:
+      "Fictional sample incidents. Follow-ups exist only in this browser page session; refreshing clears them. No external task system is updated.",
+    availableIncidents: incidents.map(({ id, title, status }) => ({
+      id,
+      title,
+      status,
+    })),
+    selectedIncident: {
+      ...findIncident(selectedId),
+      timeline: [...findIncident(selectedId).timeline],
+    },
+    followups: followups.filter((task) => task.incidentId === selectedId),
+  };
+}

--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -2,12 +2,13 @@
 
 | Doc | When you need it |
 |---|---|
+| [sponsors.md](sponsors.md) | Runnable recipes for all eight sponsors |
 | [setup.md](setup.md) | Getting from clone to a first reply |
 | [channels.md](channels.md) | How Channels delivery actually works, and the Slack/Teams setup order |
-| [surfaces.md](surfaces.md) | Adding a surface: web, mobile, voice, ChatGPT plugin |
-| [model-switching.md](model-switching.md) | Changing model, or failing over to OpenRouter mid-demo |
+| [surfaces.md](surfaces.md) | Choosing a surface and understanding its actual capabilities |
+| [model-switching.md](model-switching.md) | Choosing OpenAI or OpenRouter and understanding provider precedence |
 | [tools-and-context.md](tools-and-context.md) | Giving the agent tools, native UI, and approval gates |
-| [durable-work.md](durable-work.md) | Work that outlives a chat turn, and the two-tier approval |
+| [durable-work.md](durable-work.md) | Approved research and explicit same-thread result retrieval |
 | [deploy.md](deploy.md) | Getting it off your laptop before 15:30 |
 | [demo-prompts.md](demo-prompts.md) | What to type to get a demo in thirty seconds |
 | [troubleshooting.md](troubleshooting.md) | It boots, reports online, and answers nothing |

--- a/dev-docs/channels.md
+++ b/dev-docs/channels.md
@@ -29,7 +29,7 @@ you have drifted off the managed path.
 | Works | Does not |
 |---|---|
 | mentions, messages | slash commands |
-| button and select clicks (so HITL fires) | modal submissions (`view_submission`) |
+| button and select clicks (nonblocking handlers) | modal submissions (`view_submission`) |
 | reactions | |
 
 Code that registers `onCommand` or `onModalSubmit` compiles, starts, reports
@@ -72,5 +72,11 @@ Multiple runtimes declaring the same Channel name race per delivery, and the
 loser gets nothing — silently. The tell is a Slack reply your terminal knows
 nothing about. **Give a local runtime its own Intelligence project.**
 
-Replicas in production are fine: one runtime claims each delivery, so identical
-builds scale horizontally.
+Run **one listener instance for the shipped proposal and research approval
+buttons**. Their inline handlers live in the process that posted the card. A
+replica can claim the click without that closure, even with an identical build.
+Keep the listener running until approval; before scaling, implement shared
+persistent bindings and reconstructible registered-component handlers.
+
+Managed delivery does not support blocking `awaitChoice`; the proposal demo
+posts a card and a later click reports its decision without resuming the agent.

--- a/dev-docs/demo-prompts.md
+++ b/dev-docs/demo-prompts.md
@@ -1,93 +1,79 @@
-# Demo prompts
+# A complete incident demo
 
-Thirty seconds from "it's running" to "that's the demo." The example agent is an
-**on-call assistant** — it lives in the channel where the incident is already
-being discussed, which is the whole reason it belongs there.
+The point is to show work informed by its surroundings and a result visible where the interaction began. Choose either the Slack workflow or the browser workflow, then add only the sponsor capabilities you need.
 
-## Set the scene first
+## Slack: context, sources, card, follow-up
 
-The demo only works if the thread has something in it, because the point is that
-the agent reads instead of asking. Paste these into a Slack thread as separate
-messages before you mention the bot:
+Prerequisites: [Slack setup](setup.md), your selected model provider, Exa for research, and an isolated Ambiguous AI demo workspace for the external-task step. The [sponsor recipes](sponsors.md) give the exact configuration.
 
-> checkout is timing out for a bunch of EU customers
-> started around 02:14, right after the web deploy went out
-> rolled web back, didn't help — still seeing 4s+ on /checkout
+### 1. Establish the surrounding context
+
+Before mentioning the bot, put these messages into a thread:
+
+> checkout is timing out for EU customers
+>
+> started around 02:14, right after the web deploy
+>
+> rolled web back, did not help — still seeing 4s+ on /checkout
+>
 > queue depth on payments-worker is climbing
 
-## Rung 1 — it's reachable
+Then ask:
 
-> @agent you around?
+> @agent catch me up on this incident. Read this thread and show an incident card.
 
-Proves Slack → Intelligence → your process end to end.
+Expected: `read_thread` followed by `incident_card`. Check that it includes the failed rollback and growing queue, without your prompt restating them. Ask for a timeline to exercise `timeline`.
 
-## Rung 2 — it's situated
+### 2. Research with visible sources
 
-> @agent catch me up
+> @agent use web search to find documented causes of payment-worker retry storms and safe investigation steps. Include source links and separate published guidance from what this thread proves.
 
-Calls `read_thread`, then `incident_card`. **The line to say out loud: nobody told
-it what the incident was.** It knows the impact, the start time, that the rollback
-failed, and that the queue is climbing — because it read the thread.
+Expected: `search_web` via Exa and inspectable URLs. Search results do not prove the cause of this sample incident. No log reader is included.
 
-Then the test that separates rung 1 from rung 2:
+### 3. Approve a concrete follow-up
 
-> @agent what changed right before this started?
+> @agent propose creating one task in our Ambiguous workspace: “Investigate payments-worker retry spike.” Include the failed rollback, rising queue depth, and useful source links. Ask for approval before creating it; do not send mail or change production.
 
-It answers "the web deploy at 02:14" from the thread. Delete the thread context
-and the same question has no answer.
+Review the proposed action and approve only the intended demo-workspace write. The managed proposal card records the decision but executes nothing and does not resume the agent. In a separate message, explicitly ask it to create that demo-workspace task and return its record URL. Production proposals remain demonstration-only.
 
-## Rung 3 — it's native
+Expected: a **real task record**, with a returned URL you can open from the thread. Verify its title and contents in the workspace. A card or “done” sentence without an actual record is not a successful task demo. MCP tools come from the live workspace; this route is not live-account-verified by the kit's offline checks.
 
-> @agent build me a timeline
+The prompt and `propose_action` guide approval behavior but do not enforce approval around every external MCP call. Use a demo workspace. For an enforced authorization example, run the standalone [Auth0 recipe](../examples/auth0/README.md).
 
-Calls `timeline` and renders real Block Kit — not an ASCII table in a code fence.
-This is the artifact handover and the postmortem are written from.
+### Alternative closing beat: approved durable research
 
-## The moment that wins it
+With Trigger.dev and Exa configured, follow [durable setup](durable-work.md):
 
-> @agent restart the payments worker
+> @agent queue background web research about payment-worker retry storms and safe investigation steps. Use run_deep_work.
 
-The agent calls `propose_action` and **stops**. You get a card naming the blast
-radius and whether it's reversible, with Approve and Hold.
+Click **Approve** while the listener is running, copy the `run_...` ID, and continue chatting. Then, in the original thread:
 
-**Click Hold, on camera.** An agent that visibly declines to touch production is a
-better demo than one that always says yes — and an outage is exactly when people
-feel entitled to skip the gate.
+> @agent check run_YOUR_ID
 
-Then, for the durable path (needs `TRIGGER_SECRET_KEY`):
+Expected: `check_deep_work` returns research sources or the run's actual status. Retrieval works after a listener restart once approval is recorded. Results are requested explicitly, not pushed. Demonstrate **Cancel** on a second run to show that declined research does not execute.
 
-> @agent go trawl the last hour of payments-worker logs
-
-Calls `run_deep_work`: creates a waitpoint, hands the job to Trigger.dev, posts an
-approval card, and **returns immediately**. The thread stays usable while a job
-that outlives the conversation waits on a human.
-
-## Grounding (needs `EXA_API_KEY`)
-
-> @agent is there a known issue with the Stripe API right now?
-
-Calls `search_web`. With `showToolStatus: true` the room watches it search.
-
-## Iterating without Slack
+## Browser: ambient context and visible local actions
 
 ```bash
-npm run dev:local
+npm run dev:web
 ```
 
-```
-› you're in an on-call channel at 2am. three engineers are arguing about whether to fail over. what do you do?
-```
+Open `http://localhost:3100` and select an incident. Try:
 
-Fastest way to tune the prompt — no Slack round trip.
+> What is happening with the selected incident? Show an incident card and a timeline.
 
-## For the two-minute video
+> Create a follow-up for this incident to investigate the retry spike.
 
-1. **Ten seconds of context.** The surface, not the tech: "this is our on-call
-   channel at 2am."
-2. **One mention, one native card.** `catch me up` → `incident_card`. No narration
-   over dead air.
-3. **The gate, declined.** `restart the payments worker` → Hold. This is the beat.
-4. **Same agent, second surface.** Ten seconds of the terminal, phone, or voice —
-   the "one agent, every surface" claim shown rather than asserted.
-5. **Say why the context matters.** The submission asks for it in writing; say it
-   out loud too: *nobody had to re-explain the outage.*
+> Select the other incident and tell me what changed.
+
+Expected: `incident_card`, `timeline`, `create_followup`, and `select_incident` as appropriate. The selected incident and follow-up list should visibly change. The context is derived from the displayed sample data; local tasks last only for this page session. `propose_action` provides approval UI but does not execute a production action. Web chat does not register Exa search; use Slack or the standalone recipes for that step.
+
+## Record a focused video
+
+1. Show the surface and existing context.
+2. Ask a question that relies on that context.
+3. Show the native assessment and one complete action or returned research result.
+4. Open the actual record or source link.
+5. Explain what the surrounding context made possible.
+
+A second surface is optional. State what is sample data, what changed locally, and what reached a real service. See [SUBMISSION.md](../SUBMISSION.md) for the event checklist.

--- a/dev-docs/deploy.md
+++ b/dev-docs/deploy.md
@@ -11,7 +11,7 @@ Deploy it like a queue consumer.
 | Google Cloud Run *(min-instances ≥ 1, CPU always allocated)* | Netlify functions |
 | Fly.io, Render, plain Docker | any serverless request handler |
 
-`apps/web` (once you add it) is an ordinary Next.js app and deploys to Vercel
+`apps/web` is an ordinary Next.js app and deploys to Vercel
 fine. It is only the listener that needs a persistent process.
 
 ## Requirements
@@ -35,8 +35,11 @@ reconnect. Alert on `error`.
 
 ## Scaling
 
-Claim-based delivery means replicas are safe: one runtime claims each delivery.
-Run identical builds and identical Channel declarations.
+Run **one listener instance for this demo**. Proposal and research approval
+buttons use process-local inline handlers. Claim-based delivery gives each event
+to one runtime; an identical replica may claim a click but lack its handler.
+Restarting also loses pending inline handlers. Before scaling, implement shared
+persistent action bindings and reconstructible registered-component handlers.
 
 **But not across environments.** Two runtimes declaring the same Channel name in
 the same project race per delivery and the loser gets nothing, silently. Give

--- a/dev-docs/durable-work.md
+++ b/dev-docs/durable-work.md
@@ -1,87 +1,50 @@
-# Durable work and the two-tier approval
+# Approved research with Trigger.dev
 
-A Slack turn is a request/response cycle. Anything that takes ten minutes,
-survives a restart, or needs retries does not belong inside it — and this is the
-one thing a Channels listener genuinely cannot do on its own.
+`run_deep_work` queues public-web research and posts an approval card. The worker waits up to 30 minutes for a decision, then calls Exa only when approved. The chat turn can finish while the job is waiting.
 
-## The two tiers, and why there are two
-
-| Tier | Mechanism | For |
-|---|---|---|
-| **In-thread** | `confirm_action` → `thread.awaitChoice` blocks the tool | cheap, reversible, seconds |
-| **Durable** | `run_deep_work` → Trigger.dev waitpoint | slow, expensive, outlives the conversation |
-
-The second one inverts the usual shape. Instead of the chat turn blocking while
-work happens, **the work blocks while the human decides** — and the thread stays
-live the whole time.
-
-```
-channel tool   wait.createToken()  ─────────────▶  a 30-minute waitpoint
-               tasks.trigger("deep-work")  ─────▶  task parks on wait.forToken()
-               thread.post(<approval card/>)
-               return immediately                  ← the agent does NOT wait
-
-human taps     wait.completeToken(id, { approved, decidedBy })
-
-the task       wakes up, does the long thing, and reports back
-```
+**Results are retrieved on request.** The card shows a `run_...` ID. Ask the agent to check that ID in the original conversation; `check_deep_work` retrieves the stored run, validates its originating Channel/conversation, and posts status or sources there. Results are not pushed automatically.
 
 ## Setup
 
+1. Create a [Trigger.dev project](https://cloud.trigger.dev) and obtain its project ref and Development secret key. Use a key with the permissions required to trigger/retrieve runs and create/complete waitpoints.
+2. Add `TRIGGER_PROJECT_REF`, `TRIGGER_SECRET_KEY`, and `EXA_API_KEY` to root `.env` for the Slack listener.
+3. Create an ignored `apps/durable/.env` containing the same project ref and Exa key for the worker. Do not assume the worker reads root `.env`.
+4. Start the worker from its project directory:
+
 ```bash
 cd apps/durable
-npx trigger.dev@latest dev
+npx trigger.dev@latest dev --env-file .env
 ```
 
-Two env vars, both in the root `.env`:
+Follow CLI login if requested. The `--env-file` option loads the project ref into the CLI/config process; the worker's local `.env` also supplies Exa to task processes. See [CLI options](https://trigger.dev/docs/cli-dev-commands) and [task environment variables](https://trigger.dev/docs/deploy-environment-variables). For deployed tasks, configure Exa in the appropriate Trigger dashboard environment as well.
 
-```dotenv
-TRIGGER_SECRET_KEY=tr_dev_...      # "Trigger only" access, Development env
-TRIGGER_PROJECT_REF=proj_...       # from the Trigger.dev dashboard
+In another terminal, from the repository root:
+
+```bash
+npm run check-env
+npm run dev:slack
 ```
 
-Without `TRIGGER_SECRET_KEY` the `run_deep_work` tool is **not registered at
-all** — the agent is never handed a tool that would fail when it called it. The
-pre-flight check says so rather than leaving you guessing.
+The run/check tools are optional and require the configured Trigger path. A project ref and working worker are needed in addition to the listener's key.
 
-## Things worth knowing
+## Demonstrate the complete loop
 
-- **Import from `@trigger.dev/sdk`, never `@trigger.dev/sdk/v3`**, and never
-  `client.defineJob()` — that is the deprecated v2 API.
-- **Trigger tasks with a type-only import** (`import type { deepWork }`) so the
-  task's code never gets bundled into the listener.
-- **The waitpoint carries the decision, not just a signal.** Completing it with
-  `{ approved, decidedBy }` means the durable task has an audit trail without a
-  second lookup.
-- **Credit the clicker, not the asker.** The `onClick` context carries its own
-  `user`, which is not necessarily whoever prompted the agent.
-- **`InteractionContext` has no `messageRef`.** It carries `thread`, `message`,
-  `action`, `values`, `user`, `actor`, `platform` and an optional `openModal` —
-  despite what the UI reference implies. To edit the card you posted, keep the
-  `MessageRef` that `thread.post()` returned in a binding the handler closes
-  over, which is what `apps/channel-slack/src/durable.tsx` does.
-- **Inline handlers route in-process only** and are lost on restart. For
-  approvals that must survive a deploy, register the component via
-  `createChannel({ components })` and configure a durable store.
+In an existing Slack incident thread:
 
-## The last mile: out-of-band approval
+> @agent queue background web research about payment-worker retry storms and safe investigation steps. Use run_deep_work.
 
-For actions where "somebody clicked a button in a channel" is not a strong enough
-claim about *who* approved, the same waitpoint should be completed by an
-out-of-band approval on the person's own device — Auth0 CIBA.
+1. Copy the displayed run ID.
+2. Click **Approve** while the listener remains running. The card identifies that the question will be sent to Exa; it does not grant log access or production actions.
+3. Continue chatting, then ask: `@agent check run_YOUR_ID` in that same thread.
+4. Confirm the returned source links or explicit pending/failure outcome.
+5. Optionally restart the listener after approval and retrieve the same ID again. Retrieval does not depend on an in-memory run map.
 
-`apps/durable/src/approvals.ts` is that seam, and it is deliberately a **throwing
-stub rather than a plausible guess**. The flow is clear (POST `/bc-authorize`,
-get an `auth_req_id`, poll `/oauth/token`), but the exact parameter set —
-`binding_message`, the `login_hint` format, `audience`, the `grant_type` URN —
-and the polling error codes are not in the overview docs, and writing those from
-memory is how you get an integration that 400s for reasons nobody can see.
+Try **Cancel** in a separate run: no research should execute. An unanswered waitpoint expires. The check tool reports declined, timed-out, pending, failed, or completed outcomes instead of pretending every run succeeded. Repeated checks may post the result again.
 
-Read [Auth0's async authorization quickstart](https://auth0.com/ai/docs/get-started/asynchronous-authorization),
-then complete the waitpoint from your callback:
+## Boundaries
 
-```ts
-await wait.completeToken(tokenId, { approved: true, decidedBy: sub });
-```
+The worker can outlive a chat turn and the listener. **Inline approval buttons require one listener instance and cannot survive a restart or route to another replica**; approve before restarting, or queue a new run. An old unapproved run will expire. The implementation does not expose a supported outbound Channels transport for automatic worker-to-thread pushes, so the explicit check is part of the demo.
 
-The durable task is already waiting on it. Nothing else in the chain changes.
+`propose_action` separately posts a nonblocking proposal. Its click reports the decision only; it neither runs production commands nor automatically resumes the agent. `apps/durable/src/approvals.ts` remains an unimplemented CIBA extension. The runnable [Auth0 example](../examples/auth0/README.md) demonstrates machine authorization, not human consent or Trigger integration.
+
+Customize [the worker](../apps/durable/src/trigger/deep-work.ts) and [the Channel tools](../apps/channel-slack/src/durable.tsx). Offline tests cover the research decision and result-retrieval behavior; a live Slack/Trigger/Exa round trip requires your accounts.

--- a/dev-docs/model-switching.md
+++ b/dev-docs/model-switching.md
@@ -1,73 +1,42 @@
-# Switching models
+# Choose a model provider
 
-## Change the model
+Set `MODEL_PROVIDER` explicitly in root `.env` so another saved credential cannot change your chat provider.
+
+## OpenAI
 
 ```dotenv
+MODEL_PROVIDER=openai
+OPENAI_API_KEY=your-key
 MODEL=gpt-5.6-sol
 ```
 
-| Model | Note |
-|---|---|
-| `gpt-5.6-sol` | the kit default · flagship · $5.00/$30.00 per MTok |
-| `gpt-6-astra` | most capable — built for the hardest end-to-end work |
-| `gpt-5.6-terra` | balances capability with cost |
-| `gpt-5.6-luna` | cheapest · $0.20/$1.20 per MTok |
+Obtain a key from [OpenAI](https://platform.openai.com/api-keys). `MODEL` is a model ID available to your account. The kit accepts a bare OpenAI name or a matching `openai/` or `openai:` prefix.
 
-**On cost:** the default is a flagship model, which is the right call for an agent
-that has to read a thread, pick a tool, and render a card in one turn. If you are
-running on hackathon credits and watching them drain, `gpt-5.6-luna` is roughly
-25x cheaper per token and holds up fine for chat-shaped work — it is a one-line
-change and nothing else in the kit cares.
-
-The runtime's resolver normalises `/` and `:`, so `openai/gpt-5.6-luna` and
-`openai:gpt-5.6-luna` are the same thing. A bare name gets `openai:` prefixed.
-
-## Change the provider
-
-Name it explicitly and the kit passes it through:
+## OpenRouter
 
 ```dotenv
-MODEL=anthropic/claude-sonnet-4-6     # needs ANTHROPIC_API_KEY
-MODEL=google/gemini-2.5-flash         # needs GOOGLE_API_KEY
+MODEL_PROVIDER=openrouter
+OPENROUTER_API_KEY=your-key
+MODEL=openai/gpt-5.6-sol
 ```
 
-## Fail over to OpenRouter mid-demo
+Obtain a key from [OpenRouter](https://openrouter.ai/keys) and choose an available [publisher/model slug](https://openrouter.ai/models). No OpenAI key is required for this chat path. Re-run the same incident prompt to compare model behavior; check source use and tool results as well as answer quality.
 
-This is the one to remember. If OpenAI rate-limits you at 14:00 with a demo at
-15:30, add one line:
+The adapter uses OpenRouter's OpenAI-compatible chat-completions endpoint. Bare model names receive `openai/`; provider separators are normalized while suffixes such as `:free` are preserved. Optional `PUBLIC_APP_URL` and `APP_TITLE` configure attribution headers.
 
-```dotenv
-OPENROUTER_API_KEY=sk-or-...
+```bash
+npm run check-env
+npm run dev
 ```
 
-`packages/agent-core/src/model.ts` detects it and routes everything through
-OpenRouter's OpenAI-compatible endpoint, with cost-optimized routing and provider
-fallbacks behind it. `MODEL` is turned into an OpenRouter slug (`gpt-5.6-sol` →
-`openai/gpt-5.6-sol`); set a full slug yourself to pick a different vendor:
+Restart the app after editing `.env`. Provider availability, tool support, access and pricing depend on the chosen account and model.
 
-```dotenv
-MODEL=anthropic/claude-sonnet-4-6
-```
+## Existing configurations
 
-Attribution headers (`HTTP-Referer`, `X-OpenRouter-Title`) are sent so your build
-shows up on OpenRouter's public rankings. Override with `PUBLIC_APP_URL` and
-`APP_TITLE`.
+With `MODEL_PROVIDER` absent, an `OPENROUTER_API_KEY` selects OpenRouter. Otherwise the prefix in `MODEL` selects a provider, defaulting to OpenAI. Existing `anthropic/` and `google/` prefixes remain supported with `ANTHROPIC_API_KEY` and `GOOGLE_API_KEY`. An explicit non-router provider must match the model prefix; unsupported providers fail with a configuration error.
 
-> Why a `LanguageModel` instance rather than a model string: the runtime's string
-> resolver reads everything before the first separator as the provider name,
-> which would eat the `openai/` half of an OpenRouter slug.
+The browser's `/voice` route uses OpenAI Realtime independently of chat selection. It always needs `OPENAI_API_KEY`; use `npm run check-env -- --voice` before testing it. The MCP server supplies tools to a host and does not use this model resolver. The Mozilla example has its own Python configuration.
 
-## Swap the whole agent
+## Bring another agent backend
 
-`packages/agent-core/src/agent.ts` returns CopilotKit's `BuiltInAgent`. To use
-LangGraph, CrewAI, Mastra, Pydantic AI, or Google ADK instead, return an
-`HttpAgent` pointed at your agent's AG-UI endpoint:
-
-```ts
-import { HttpAgent } from "@ag-ui/client";
-export function makeAgent(threadId: string) {
-  return new HttpAgent({ url: process.env.AGENT_URL! });
-}
-```
-
-Nothing else in the kit changes. That is what AG-UI is for.
+The shared factory in [agent.ts](../packages/agent-core/src/agent.ts) can return an `HttpAgent` pointed at your AG-UI endpoint. Validate context and tool support on each surface you use; voice and the standalone MCP server follow separate paths.

--- a/dev-docs/setup.md
+++ b/dev-docs/setup.md
@@ -1,78 +1,74 @@
 # Setup
 
-## Tier 0 — one credential, one process (~5 min)
+## Start with one model provider
+
+Requires Node.js 22+. From the repository root:
 
 ```bash
 npm install
-cp .env.example .env      # then paste an OPENAI_API_KEY
+cp .env.example .env
+```
+
+Edit `.env` using one provider:
+
+```dotenv
+MODEL_PROVIDER=openai
+OPENAI_API_KEY=your-key
+MODEL=gpt-5.6-sol
+```
+
+Or use OpenRouter, without an OpenAI key:
+
+```dotenv
+MODEL_PROVIDER=openrouter
+OPENROUTER_API_KEY=your-key
+MODEL=openai/gpt-5.6-sol
+```
+
+Select an available model in your provider account. Restart after changing configuration. See [model switching](model-switching.md) for precedence and legacy provider prefixes.
+
+```bash
+npm run check-env
 npm run dev
 ```
 
-With no Channel configured, `npm run dev` starts the **local surface** — the same
-agent in your terminal. Use it to iterate on the prompt and the model with a
-sub-second loop instead of a Slack round trip.
+With no Channel configured, `dev` starts terminal chat. The terminal has your selected model and prompt, but no thread-history, native-card, or Exa search tools. For the sample incident workspace, run `npm run dev:web` and open the URL printed by Next.js.
 
-```
-› recap what you can do
-```
+## Add Slack
 
-`npm run check-env` at any point prints a numbered list of what is missing.
-
-## Tier 1 — the agent lives in Slack (~15 min)
-
-No tunnel. No ngrok. No public URL of your own. Intelligence hosts the provider
-webhook and dials your process over an outbound websocket.
-
-**Fastest path — let your coding agent drive the consoles:**
+Intelligence manages platform credentials and delivers over an outbound socket. Your listener stays running; no public tunnel is needed.
 
 ```bash
-npm run channel:setup      # npx copilotkit@latest channels setup
+npm run channel:setup
 ```
 
-That installs a skill, prints a prompt, and copies it to your clipboard. Paste it
-into Claude Code or Cursor. It drives the Slack and Intelligence consoles in your
-own signed-in session; you type the secrets, it does the clicking.
+Follow the setup instructions it prints. Alternatively, create the Channel **before** the Slack app so the wizard can generate the correct manifest:
 
-**By hand:**
+```bash
+npx copilotkit@latest channels add --name my-agent \
+  --display-name "My Agent" --adapter slack --json
+```
 
-1. **Create the Channel first.** The wizard generates a Slack app manifest already
-   pointed at the correct request URL, so doing this second means creating the
-   wrong app.
+1. Complete the platform setup and installation.
+2. Copy the Channel **Code** into `CHANNEL_CODE` in root `.env`.
+3. Create a project-scoped Intelligence API key and set `INTELLIGENCE_API_KEY`.
+4. Run `npm run dev`; with the Channel configured this starts its listener.
+5. In Slack, `/invite @yourbot`, then mention it inside a thread.
 
-   ```bash
-   npx copilotkit@latest channels add --name my-agent \
-     --display-name "My Agent" --adapter slack --json
-   ```
+```bash
+npm run channel:status
+```
 
-2. Put the Channel **Code** in `CHANNEL_CODE`. It must match character for
-   character: lowercase letters and digits, single hyphens, starting with a
-   letter, 3–64 chars, never the literal `channels`.
+Use a separate Intelligence project for local and deployed listeners. Two listeners sharing a Channel can compete for deliveries. See [troubleshooting](troubleshooting.md).
 
-3. Create a project-scoped key under **API Keys** in the Intelligence sidebar →
-   `INTELLIGENCE_API_KEY`.
+## Add one useful capability
 
-4. `npm run dev` now starts the Channels listener instead of the local surface.
+[Choose a sponsor recipe](sponsors.md): Exa search, Trigger.dev research, an Ambiguous AI follow-up, a protected Auth0 action, or a Mozilla agent trace. Each has its own prerequisites; adding a key does not configure every service.
 
-5. In Slack: `/invite @yourbot` into a channel, then @-mention it. **Workspace-
-   installed is not the same as channel member** — Slack emits no `app_mention`
-   event at all for a channel the app is not in.
+## Verify offline, then prove the live path
 
-`npm run channel:status` is a real doctor command. Use it before you start
-guessing.
+```bash
+npm run verify
+```
 
-## Tier 2 — opt-in
-
-Each of these is one env var and one file. Pick two, not six.
-
-| Add | Gets you |
-|---|---|
-| `EXA_API_KEY` | grounded web search as an agent tool |
-| `OPENROUTER_API_KEY` | model failover — see [model-switching.md](model-switching.md) |
-| `AMBIGUOUS_API_KEY` | a 17-app workplace to act in (`npx ambiguous auth signup`) |
-| `TRIGGER_SECRET_KEY` | durable work + waitpoint approvals |
-
-## Requirements
-
-- **Node.js 22+.** Channels needs global `WebSocket`. `nvm use` reads `.nvmrc`.
-- A CopilotKit Intelligence project (free tier) for tier 1. There is no DIY path
-  — Intelligence owns the platform credentials and delivery.
+This needs no `.env` and makes no live sponsor calls. It checks workspace types, tests, and the MCP stdio protocol. Run `npm run check-env` separately for configured startup, then demonstrate an actual reply and the sponsor result you plan to show. [Demo prompts](demo-prompts.md)

--- a/dev-docs/sponsors.md
+++ b/dev-docs/sponsors.md
@@ -1,0 +1,93 @@
+# Sponsor recipes
+
+Choose a sponsor because its capability improves your demo. All eight are optional additions except the model provider needed by the chat quickstart. Auth0 and Mozilla are independent examples; installing them is not required for root startup.
+
+Each recipe below gives a concrete result to verify. Live account access, billing and external writes are separate from `npm run verify`. Organizer offers belong in [CREDITS.md](../CREDITS.md).
+
+## OpenAI
+
+- **Value:** Reason about the incident context and choose useful actions.
+- **Access:** Create an [API key](https://platform.openai.com/api-keys) with access to the model you select.
+- **Configure:** In root `.env`, set `MODEL_PROVIDER=openai`, `OPENAI_API_KEY`, and `MODEL=gpt-5.6-sol` (the kit default, subject to account availability).
+- **Run:** From root, `npm run check-env`, then `npm run dev:local`. Describe the incident and ask for an assessment. Or run `npm run dev:web` to use the incident workspace.
+- **Result:** An assessment grounded in the supplied or selected incident. In web, ask for an incident card and check its facts against the page.
+- **Customize:** [prompt.ts](../packages/agent-core/src/prompt.ts), [agent.ts](../packages/agent-core/src/agent.ts), and [model.ts](../packages/agent-core/src/model.ts).
+- **Status:** Chat adapter implemented. Live model access needs your key. `/voice` is a separate OpenAI Realtime path requiring an OpenAI key even when chat uses OpenRouter.
+
+## CopilotKit
+
+- **Value:** Give an agent the context and interactions of the surface where work happens.
+- **Access:** Web needs your chosen model provider. Slack additionally needs an [Intelligence project](https://intelligence.copilotkit.ai/) and a platform installation; follow [setup](setup.md).
+- **Configure:** Model settings in root `.env`; add `CHANNEL_CODE` and project-scoped `INTELLIGENCE_API_KEY` for Slack.
+- **Run:** `npm run dev:web`, open `http://localhost:3100`, and ask “What is happening with the selected incident? Create a follow-up to investigate the retry spike.” For Slack, `npm run channel:setup`, then `npm run dev` after configuration, invite the bot and mention it in a populated thread.
+- **Result:** The browser's selected incident informs the answer and a follow-up appears on the page. In Slack, `read_thread` informs `incident_card` and `timeline` native cards.
+- **Customize:** [frontend actions](../apps/web/src/components/app-control.tsx), [web page](../apps/web/src/app/page.tsx), and [Slack tools](../apps/channel-slack/src/tools.tsx).
+- **Status:** Implemented, with sample/session-only browser tasks. Slack/Teams installation and live delivery need validation. Approval UI alone does not perform production actions. See [surface differences](surfaces.md).
+
+## OpenRouter
+
+- **Value:** Choose a model through one gateway and compare how it handles the same incident and tools.
+- **Access:** Obtain an [OpenRouter key](https://openrouter.ai/keys); choose an available [model slug](https://openrouter.ai/models).
+- **Configure:** Root `.env`: `MODEL_PROVIDER=openrouter`, `OPENROUTER_API_KEY`, `MODEL=openai/gpt-5.6-sol` or your chosen publisher/model. No OpenAI chat key is required.
+- **Run:** `npm run check-env`, then `npm run dev:local` or `npm run dev:web`. Repeat the same incident question after changing `MODEL` and restarting.
+- **Result:** A response through the selected model. Verify model/provider usage in your account; compare source fidelity and successful tool execution rather than prose alone.
+- **Customize:** [model.ts](../packages/agent-core/src/model.ts); optional `PUBLIC_APP_URL` and `APP_TITLE` set attribution headers.
+- **Status:** Chat-completions adapter implemented. Model availability and tool behavior depend on the selected model. See [provider precedence](model-switching.md).
+
+## Exa
+
+- **Value:** Ground investigation suggestions in inspectable public sources.
+- **Access:** Obtain an [Exa API key](https://dashboard.exa.ai/api-keys).
+- **Configure:** Root `.env`: `EXA_API_KEY` and `EXA_SEARCH_TYPE=fast`, plus Slack/model settings for this recipe.
+- **Run:** `npm run dev:slack`. In the incident thread ask: “Use web search to find documented causes of payment-worker retry storms. Include source links and distinguish general guidance from our incident facts.”
+- **Result:** `search_web` returns source URLs and the answer cites them. Open the links to verify the claims. Public web search does not inspect your logs.
+- **Customize:** [search.ts](../packages/agent-core/src/capabilities/search.ts) and [Slack search tool](../apps/channel-slack/src/tools.tsx).
+- **Status:** Implemented in Slack, MCP and the voice search route; not registered in terminal or web chat. Live search needs the key. Trigger research additionally needs its worker configured with Exa.
+
+## Trigger.dev
+
+- **Value:** Research can wait for approval and finish after the initiating chat turn.
+- **Access:** Create a [Trigger.dev project](https://cloud.trigger.dev) and obtain its Development secret key/project ref. Exa supplies the research.
+- **Configure:** Root `.env`: `TRIGGER_SECRET_KEY`, `TRIGGER_PROJECT_REF`, `EXA_API_KEY`, and Slack/model settings. Add project ref and Exa key to ignored `apps/durable/.env` for the worker as described in [durable setup](durable-work.md).
+- **Run:** In one terminal, `cd apps/durable` and `npx trigger.dev@latest dev --env-file .env`. In another, from root, `npm run dev:slack`. Ask for background web research using `run_deep_work`; approve while the listener is running. Then ask `check run_YOUR_ID` in the same thread.
+- **Result:** `check_deep_work` posts the actual run status or research sources in the originating conversation. Canceling a separate run prevents research.
+- **Customize:** [deep-work.ts](../apps/durable/src/trigger/deep-work.ts) and [durable.tsx](../apps/channel-slack/src/durable.tsx).
+- **Status:** Worker and retrieval path implemented; live accounts required. Results are requested, not pushed. Inline approval buttons require the listener to remain running until clicked; retrieval after approval survives its restart.
+
+## Auth0
+
+- **Value:** Permit a concrete incident action only for an authorized service identity.
+- **Access:** Create an Auth0 tenant, RS256 API, `create:followups` permission, and a machine-to-machine application granted that permission. [Full setup](../examples/auth0/README.md)
+- **Configure:** `AUTH0_DOMAIN`, `AUTH0_AUDIENCE`, `AUTH0_CLIENT_ID`, `AUTH0_CLIENT_SECRET` in root ignored `.env`. The server needs only domain/audience; the client needs all four.
+- **Run:** From root, `npm ci --prefix examples/auth0`, then `npm test --prefix examples/auth0`. For the live demonstration run `node --env-file=.env examples/auth0/server.mjs` and, in another terminal, `node --env-file=.env examples/auth0/client.mjs`.
+- **Result:** An unauthenticated call gets 401; an authorized call gets 201 and prints a local incident follow-up record. Tokens are not printed.
+- **Customize:** [client.mjs](../examples/auth0/client.mjs) for incident input; [server.mjs](../examples/auth0/server.mjs) for the protected action.
+- **Status:** Runnable standalone recipe with offline JWT/scope tests. Records last until the local server stops. Live Auth0 flow requires your tenant. This is machine authorization, not human consent, CIBA, or a Trigger integration; the CIBA extension remains unimplemented.
+
+## Mozilla.ai
+
+- **Value:** Inspect an agent's incident tool call and result through a saved trace.
+- **Access:** Install Python 3.11–3.13 and use an OpenAI API key for this focused example; no Mozilla account is required. [Full setup](../examples/mozilla/README.md)
+- **Configure:** Export `OPENAI_API_KEY` in your environment. The Python script does not automatically load root `.env`; use your secret manager. Default model is `openai:gpt-4o-mini`, independent of root `MODEL`.
+- **Run:** From root:
+
+```bash
+python3.12 -m venv examples/mozilla/.venv
+examples/mozilla/.venv/bin/python -m pip install -r examples/mozilla/requirements.txt
+examples/mozilla/.venv/bin/python -m unittest discover -s examples/mozilla -v
+examples/mozilla/.venv/bin/python examples/mozilla/trace_incident.py
+```
+
+- **Result:** Mozilla `any-agent` TinyAgent calls `read_incident`, prints an assessment, and saves `examples/mozilla/traces/incident.json`. Inspect the tool span and output. Use `--model openai:MODEL_NAME` to select another supported OpenAI model.
+- **Customize:** [trace_incident.py](../examples/mozilla/trace_incident.py), including the synthetic incident fixture.
+- **Status:** Runnable independent Python recipe with offline checks. Live model execution requires your key. This demonstrates trace inspection, not a complete evaluation framework or a replacement for the shared TypeScript agent.
+
+## Ambiguous AI
+
+- **Value:** Turn the incident assessment into an actual workplace follow-up with a record link.
+- **Access:** Create a demo workspace/key using [Ambiguous AI](https://www.ambiguous.ai/): `npx ambiguous auth signup --name "On-call agent" --human-email you@example.com`. Use your own email.
+- **Configure:** Root `.env`: `AMBIGUOUS_API_KEY`, selected model settings, and Slack settings for this recipe.
+- **Run:** `npm run dev:slack`. Ask: “Propose creating one task in our Ambiguous workspace: Investigate payments-worker retry spike. Include this thread's facts. Ask for approval before creating it; do not send mail or change production.” Review and approve the intended demo write, then ask it to create the approved task and return its record URL.
+- **Result:** Open the returned URL and verify the actual record's title/content. If the connected MCP response does not provide a usable record link, complete that integration before treating the demo as successful.
+- **Customize:** [workplace.ts](../packages/agent-core/src/capabilities/workplace.ts) and [prompt.ts](../packages/agent-core/src/prompt.ts).
+- **Status:** Optional shared-agent MCP configuration implemented; live workspace tools and writes are unverified by offline checks. The approval prompt/card is not an enforced wrapper around every MCP tool. Use an isolated demo workspace and approve a concrete write. This path is different from the browser's session-only follow-ups.

--- a/dev-docs/surfaces.md
+++ b/dev-docs/surfaces.md
@@ -1,79 +1,44 @@
-# Surfaces
+# Choose a surface
 
-**Read this first: pick one surface and go deep.** The event rewards "a sharp,
-working demo" over breadth, and six shallow surfaces is the most common way to
-lose a hackathon you were winning at 14:00. The selection table lives in the
-[README](../README.md#pick-one-surface).
+Pick the place where your agent's context already exists. The following matrix describes this kit's implementation, not every feature of the underlying SDKs.
 
-The reason six exist is that `packages/agent-core` owns the model, the prompt and
-the capabilities, so each app in `apps/` is a thin binding — which makes a
-*second* surface nearly free once your first one is good. That is a closing shot
-for the video, not a second project.
+| Surface | Agent and context | UI and actions | Optional capabilities | Limits |
+|---|---|---|---|---|
+| Terminal | `makeAgent`; messages you type | Text and tool output | Ambiguous MCP through shared factory | No Slack history, incident cards, Exa tool, or approval UI |
+| Slack / Teams | `makeAgent`; `read_thread` plus channel context | `incident_card`, `timeline`, `propose_action` | Exa, Ambiguous MCP, Trigger research and `check_deep_work` | Managed Channel setup required; live platform validation required |
+| Web | `makeAgent`; selected sample incident, timeline and follow-ups via `useAgentContext` | Incident cards, timeline, approval UI; `select_incident`, `create_followup` | Ambiguous MCP through shared factory | Local follow-ups reset on refresh; web chat does not register Exa search |
+| Voice (`/voice`) | Separate `RealtimeAgent`; shares system prompt | Spoken conversation and transcript | Exa via server search route | OpenAI Realtime key required regardless of chat provider; no incident workspace context, workplace MCP, or approval tools |
+| MCP | Host's agent/model; server exposes tools | `incident_card` and HTML UI resource | Exa `search_web` | Does not call `makeAgent`; rendering depends on host; no workplace or approval tools |
+| Mobile | Web runtime's `makeAgent`; device-context tool | Expo chat and `confirm_action` UI | Shared runtime's Ambiguous MCP | Separate install; no native incident cards, Slack tools, or device verification |
 
-## What ships today
+Managed `propose_action` posts a nonblocking proposal; its later click reports a decision without automatically resuming the agent. There is no production restart implementation. Nor is it an authorization wrapper around every Ambiguous MCP tool: use an isolated demo workspace and explicitly approve intended writes. Trigger's worker separately checks its waitpoint decision before Exa research. Auth0's standalone example separately verifies a machine token and scope before creating its local record.
 
-| App | Surface | Status |
+## Launch commands
+
+Run these from the repository root after [setup](setup.md):
+
+| Surface | Command | Next step |
 |---|---|---|
-| `apps/local-chat` | your terminal | working — tier 0 |
-| `apps/channel-slack` | Slack, Teams *(swap the adapter)* | working — tier 1 |
+| Terminal | `npm run dev:local` | Type the incident context and a question |
+| Slack | `npm run dev:slack` | Invite and mention the bot in a thread |
+| Web | `npm run dev:web` | Open `http://localhost:3100` |
+| Voice | `npm run dev:web` | Run `npm run check-env -- --voice`, then open `http://localhost:3100/voice` and allow microphone access |
+| MCP HTTP | `npm run dev:mcp` | Connect an HTTP MCP client to `http://localhost:3200/mcp` |
+| Mobile | Start `npm run dev:web`, then `cd apps/mobile && npm install && npm start` | Configure the runtime URL for your simulator or device; see [mobile setup](../apps/mobile/README.md) |
 
-## What to add next, and how
+MCP protocol checks are part of `npm run verify`, independent of a live host or its widget rendering. Mobile is not an npm workspace member because React Native uses its own dependency versions.
 
-### On the web — `apps/web`
+## Slack to Teams
 
-Next.js + `@copilotkit/react-core` / `@copilotkit/react-ui` (1.70.1). Point the
-runtime at the same `makeAgent`. Generative UI here is a spectrum:
-
-- **Controlled** — `useRenderTool` with your own React components
-- **Declarative** — [A2UI](https://a2ui.org/), schema-mapped renderers
-- **Open-ended** — MCP Apps / raw HTML in a sandboxed double-iframe
-
-Unlike the Channels listener, a Next.js app deploys fine to Vercel.
-
-### In your pocket — `apps/mobile`
-
-Expo + `@copilotkit/react-native@1.70.1`. Three import surfaces: `/headless`
-(provider + hooks, no native peers), the root barrel, and `/components` (the
-rendered chat UI). Docs: [docs.copilotkit.ai/react-native](https://docs.copilotkit.ai/react-native)
-
-The interesting build here is not a chat app — it is **notifications**. A short
-async moment where the agent reaches you, you tap once, and it continues.
-
-### In the room — `apps/voice`
-
-OpenAI Realtime. Pick the transport deliberately:
-
-- **WebRTC** for browser and mobile clients capturing audio directly
-- **WebSocket** when your server receives audio from a media pipeline
-- **SIP** for telephony
-
-Models: `gpt-realtime-2.1` (reasoning + tools), `gpt-realtime-1.5` (best pure
-audio-in/audio-out), `gpt-live-transcribe`. Mint ephemeral credentials with
-`POST /v1/realtime/client_secrets` — never ship the API key to a client. Start at
-`reasoning.effort: low`.
-
-Pair with Exa's `instant` profile (~250ms); anything slower breaks the
-conversational turn.
-
-### In ChatGPT — `apps/plugin`
-
-An OpenAI **plugin** is three parts: an MCP server, skills, and optional UI.
-(The naming moved — what was pitched as the "Apps SDK" is documented at
-[developers.openai.com/plugins](https://developers.openai.com/plugins/).)
-
-Start from [/plugins/build/app-quickstart.md](https://developers.openai.com/plugins/build/app-quickstart.md).
-If you already have a Claude Code plugin, there is a conversion guide:
-[/plugins/guides/submit-claude-plugin.md](https://developers.openai.com/plugins/guides/submit-claude-plugin.md).
-
-## Slack → Teams
-
-Change the adapter when you create the Channel:
+Create a separate Channel with the Teams adapter:
 
 ```bash
 npx copilotkit@latest channels add --name my-agent \
   --display-name "My Agent" --adapter teams --json
 ```
 
-`apps/channel-slack/src/` needs no change — the same JSX renders as Adaptive
-Cards. Teams needs admin consent and a package upload, so it is the slower demo
-path. Slack is the safe one.
+Complete the Teams installation and consent flow and set the resulting Channel code. The JSX uses the SDK's native rendering path; prove the thread, card, and button interactions on your actual platform before recording a demo.
+
+## Customize
+
+The shared factory is [agent.ts](../packages/agent-core/src/agent.ts). Surface-specific tools belong in their respective app. For a new backend, validate AG-UI tool and context behavior rather than assuming identical capabilities across all surfaces.

--- a/dev-docs/tools-and-context.md
+++ b/dev-docs/tools-and-context.md
@@ -5,8 +5,9 @@ live in `apps/channel-slack/src/`.
 
 ## Tools — `defineChannelTool`
 
-A channel tool handler receives the **live thread**, which is what makes an
-approval gate possible: the tool can stop mid-execution, post a card, and block.
+A channel tool handler receives the **live thread**, so it can post native UI
+and return a result to the agent. Managed deliveries finish without waiting for
+a later button click.
 
 ```ts
 const getOncall = defineChannelTool({
@@ -47,11 +48,12 @@ list. A made-up tag does not lower to a valid IR node.
 
 ## Agent-rendered components — `defineChannelComponent`
 
-Turns a component into a tool the agent can call to draw UI itself:
+Turns a component into a tool the agent can call to draw UI itself. This minimal
+illustration is smaller than the incident schema shipped in `components.tsx`:
 
 ```tsx
-export const BriefCard = defineChannelComponent({
-  name: "brief_card",
+export const IncidentCard = defineChannelComponent({
+  name: "incident_card",
   description: "Render a short brief as a native card.",
   parameters: z.object({ headline: z.string(), summary: z.string() }),
   render({ headline, summary }) {
@@ -60,25 +62,34 @@ export const BriefCard = defineChannelComponent({
 });
 ```
 
-Pass via `createChannel({ components: [BriefCard] })`. Registration is also what
+Pass via `createChannel({ components: [IncidentCard] })`. Registration is also what
 lets handlers be recovered after a restart when a durable store is configured.
 
-This kit ships `brief_card` and `comparison_table`. **Ship at least one** — the
-setup guide gates success on a component rendering, and a global review will
-notice the difference between a text bot and one that renders native cards.
+This kit ships `incident_card` and `timeline`. Use a native artifact when it makes
+the incident easier to understand. The Context Ladder is kit design guidance,
+not an announced judging rubric.
 
-## Approval gates — `awaitChoice`
+## Managed action proposals
 
-`thread.awaitChoice<T>(ui)` posts a picker and blocks until someone clicks,
-resolving to the clicked button's `value`. Called from inside a tool handler, it
-is a hard gate: the agent is mid-tool-call and cannot proceed past a refusal.
+`propose_action` uses `thread.post()` with inline `onClick` handlers. It posts a
+native card and immediately returns **decision pending**, instructing the agent
+to stop without calling write tools. On a later delivery, **Approve** replaces
+the card with “Approved proposal. No action was executed.” **Hold** reports that
+nothing ran and the action must not be taken. Neither click resumes the agent.
+This is a proposal demo, not a production executor or a hard authorization gate
+around arbitrary MCP writes.
 
-See `confirm_action` in `apps/channel-slack/src/tools.tsx`. Button clicks are
-delivered on the managed path, so this fires without extra setup.
+The installed managed adapter sets `supportsBlockingChoice: false`:
+`thread.awaitChoice()` rejects before posting a card. Use blocking `awaitChoice`
+only with adapters that support it. Agents that emit interrupts can instead use
+`onInterrupt` plus `Thread.resume()` on a later interaction delivery; this kit's
+BuiltInAgent proposal tool does not implement that continuation flow.
 
-> Inline `onClick` handlers route **in-process only** and are lost on restart.
-> Handlers on a registered component with a durable store survive one — see
-> `references/hitl-patterns.md` in the skill.
+Run **one listener instance**, and keep it running until the click. Inline
+handlers are process-local and cannot be recovered after a restart or by another
+replica. To support replicas, use reconstructible registered-component handlers
+with shared persistent action bindings; a durable store alone cannot restore an
+inline closure.
 
 ## Context — `ContextEntry`
 

--- a/dev-docs/troubleshooting.md
+++ b/dev-docs/troubleshooting.md
@@ -3,6 +3,25 @@
 Ordered by how often each one wastes an afternoon. Every entry here has already
 cost somebody real time.
 
+## OpenRouter-only setup asks for an OpenAI key
+
+Set `MODEL_PROVIDER=openrouter` and `OPENROUTER_API_KEY` in root `.env`, choose an
+available `MODEL` slug, and restart. `npm run check-env` validates the selected
+chat provider. `/voice` separately needs OpenAI Realtime credentials. See
+[model switching](model-switching.md).
+
+## Verification versus configured startup
+
+`npm run verify` needs no `.env` or live credentials. `npm run check-env` does:
+it validates your selected provider and configured surfaces, without authenticating
+against remote services. A successful offline check does not prove live access.
+
+## Background research never arrives
+
+Results are not pushed automatically. Ask `check run_YOUR_ID` in the originating
+thread. Ensure the Trigger worker has its own Exa environment configuration and
+that approval was clicked before a listener restart. See [durable work](durable-work.md).
+
 ## It boots, reports online, and answers nothing
 
 **1. The Channel is `setup_required`, not `online`.**

--- a/examples/auth0/README.md
+++ b/examples/auth0/README.md
@@ -1,0 +1,102 @@
+# Auth0: authorize an incident follow-up
+
+Give an agent service permission to take one concrete action: create a follow-up
+for an incident. The demo first receives **401** without credentials, then obtains
+an Auth0 access token and creates a real local record with **201**. The API verifies
+the token's signature, issuer, audience, expiration and `create:followups` scope
+using Auth0's official Express middleware.
+
+This is **machine-to-machine authorization**: the identity is your application.
+It does not establish a person's consent or implement CIBA/Guardian approval. It
+is an optional standalone recipe; root startup and the existing Auth0 consent
+extension are unchanged. Use this when your hackathon agent needs a protected API.
+
+## Get access
+
+1. Create or open an [Auth0 tenant](https://auth0.com/signup).
+2. In **Applications → APIs**, create an API named `Hackathon follow-ups`, with
+   identifier `https://agents-everywhere.example/api` and signing algorithm **RS256**.
+   The identifier is an audience string; you do not need to host that URL.
+3. In the API's **Permissions**, add `create:followups`.
+4. Create a **Machine to Machine** application, authorize it for this API, and
+   grant `create:followups`. Copy its domain, client ID and client secret from
+   **Settings**. Use the same domain for the client and API.
+
+These steps follow Auth0's [Node API quickstart](https://auth0.com/docs/quickstart/backend/nodejs)
+and [client credentials guide](https://auth0.com/docs/get-started/authentication-and-authorization-flow/client-credentials-flow/call-your-api-using-the-client-credentials-flow).
+
+## Configure and run
+
+Requires Node.js 22 or newer. From the repository root:
+
+```sh
+npm ci --prefix examples/auth0
+npm test --prefix examples/auth0
+```
+
+The tests need no credentials or external services. They generate ephemeral RSA
+keys, serve a local OIDC/JWKS fixture, and exercise the real JWT middleware.
+
+For the live demo, export the following environment variables into your terminals
+using your secret manager. Keep the client secret out of shell history and source
+control. The server needs only the first two variables; the client needs all four.
+
+| Variable | Value |
+| --- | --- |
+| `AUTH0_DOMAIN` | Your bare tenant or custom hostname, e.g. `your-tenant.us.auth0.com` |
+| `AUTH0_AUDIENCE` | `https://agents-everywhere.example/api` (exact API identifier) |
+| `AUTH0_CLIENT_ID` | Your machine-to-machine application's client ID |
+| `AUTH0_CLIENT_SECRET` | That application's secret |
+
+If you use the repository's ignored `.env`, Node can load it explicitly without
+putting values into commands. Add the four variables there locally, then run:
+
+```sh
+# Terminal 1, from the repository root
+node --env-file=.env examples/auth0/server.mjs
+
+# Terminal 2, from the repository root
+node --env-file=.env examples/auth0/client.mjs
+```
+
+If the variables are already exported, use `npm start --prefix examples/auth0`
+and `npm run demo --prefix examples/auth0` instead. The server binds only to
+`127.0.0.1:3101`; the client always calls that local endpoint. Tokens remain in
+memory, and the client prints the resulting record, never the token or secret.
+
+## Expected result
+
+```text
+Unauthenticated action: denied (401). Authorized action: created (201).
+{
+  "id": "<generated UUID>",
+  "incidentId": "INC-1042",
+  "title": "Investigate retry spike after the deploy",
+  "status": "open",
+  "createdBy": "<your client ID>@clients",
+  "createdAt": "<current timestamp>"
+}
+```
+
+Records exist in the server's in-memory map until it stops. This example does not
+write to your team's issue tracker. Running the client again creates another record.
+
+A **401** means the access token is missing or invalid: check domain, audience,
+RS256 signing and expiration. **403** means the token lacks `create:followups`:
+check the M2M API grant and rerun the client to obtain a fresh token. If the token
+request itself fails, check the API authorization and application credentials.
+
+## Make it yours
+
+- Edit `action` in [client.mjs](./client.mjs) to use context from your incident or agent tool.
+- Replace `records.set` in [server.mjs](./server.mjs) with a persistent task store or
+  issue tracker call. Keep token verification and scope checks ahead of that side effect.
+- Return the record to the originating conversation so the participant can see
+  the protected action's result where they started.
+- For actions requiring a person's approval, add a separate human authorization
+  flow using [Auth0's asynchronous authorization guide](https://auth0.com/ai/docs/get-started/asynchronous-authorization).
+  A machine token alone does not provide that approval.
+
+Offline coverage includes valid, missing, malformed, expired, wrong-audience,
+wrong-issuer, incorrectly signed and insufficient-scope tokens, plus invalid
+request bodies. A live Auth0 tenant flow is a separate account-dependent check.

--- a/examples/auth0/client.mjs
+++ b/examples/auth0/client.mjs
@@ -1,0 +1,39 @@
+import { pathToFileURL } from 'node:url';
+import { configuration } from './server.mjs';
+
+export async function runDemo(config, request = fetch) {
+  const endpoint = 'http://127.0.0.1:3101/followups';
+  const action = { incidentId: 'INC-1042', title: 'Investigate retry spike after the deploy' };
+  const options = { method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(action), redirect: 'error' };
+  const denied = await request(endpoint, { ...options, signal: AbortSignal.timeout(10000) });
+  if (denied.status !== 401) throw new Error('Expected the API to reject an unauthenticated action with HTTP 401.');
+  await denied.arrayBuffer();
+  const tokenResponse = await request(`${config.issuer}oauth/token`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ grant_type: 'client_credentials', client_id: config.clientId,
+      client_secret: config.clientSecret, audience: config.audience }),
+    redirect: 'error', signal: AbortSignal.timeout(10000),
+  });
+  if (!tokenResponse.ok) throw new Error(`Auth0 token request failed (HTTP ${tokenResponse.status}); check your M2M API grant and credentials.`);
+  const token = await tokenResponse.json();
+  if (typeof token.access_token !== 'string' || !token.access_token ||
+      token.token_type?.toLowerCase() !== 'bearer') throw new Error('Auth0 did not return a Bearer access token.');
+  const response = await request(endpoint, { ...options,
+    headers: { ...options.headers, Authorization: `Bearer ${token.access_token}` },
+    signal: AbortSignal.timeout(10000) });
+  if (response.status !== 201) throw new Error(`Follow-up failed (HTTP ${response.status}); check audience and create:followups permission.`);
+  return response.json();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const record = await runDemo(configuration(process.env, true));
+    console.log('Unauthenticated action: denied (401). Authorized action: created (201).');
+    console.log(JSON.stringify(record, null, 2));
+  } catch (error) {
+    // Deliberately omit stacks, response bodies and credentials from diagnostics.
+    console.error((error instanceof TypeError || error instanceof SyntaxError) ? 'Request failed; check configuration and that the local API is running.' : error.message);
+    process.exitCode = 1;
+  }
+}

--- a/examples/auth0/package-lock.json
+++ b/examples/auth0/package-lock.json
@@ -1,0 +1,921 @@
+{
+  "name": "agents-everywhere-auth0-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agents-everywhere-auth0-example",
+      "dependencies": {
+        "express": "5.2.1",
+        "express-oauth2-jwt-bearer": "1.10.0"
+      },
+      "devDependencies": {
+        "jose": "6.1.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-oauth2-jwt-bearer": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/express-oauth2-jwt-bearer/-/express-oauth2-jwt-bearer-1.10.0.tgz",
+      "integrity": "sha512-sicg3wCTOdxiipC2noQ9XRVK94SO0wky8NmBbS6fsYZg8vWHizjvNt2HiPlUp6vLFu2eyIcWsqnJkZonqy1vzg==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.5"
+      },
+      "engines": {
+        "node": "^12.19.0 || ^14.15.0 || ^16.13.0 || ^18.12.0 || ^20.2.0 || ^22.1.0 || ^24.0.0"
+      }
+    },
+    "node_modules/express-oauth2-jwt-bearer/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.1.0.tgz",
+      "integrity": "sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/examples/auth0/package.json
+++ b/examples/auth0/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "agents-everywhere-auth0-example",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "start": "node server.mjs",
+    "demo": "node client.mjs",
+    "test": "node --test test.mjs"
+  },
+  "dependencies": {
+    "express": "5.2.1",
+    "express-oauth2-jwt-bearer": "1.10.0"
+  },
+  "devDependencies": { "jose": "6.1.3" }
+}

--- a/examples/auth0/server.mjs
+++ b/examples/auth0/server.mjs
@@ -1,0 +1,59 @@
+import { randomUUID } from 'node:crypto';
+import { pathToFileURL } from 'node:url';
+import express from 'express';
+import { auth, requiredScopes } from 'express-oauth2-jwt-bearer';
+
+// Tests use a local OIDC issuer with the same JWT verifier as the live recipe.
+export function createApp({ issuer, audience, records = new Map() }) {
+  const app = express();
+  const checkJwt = auth({ issuerBaseURL: issuer, audience, tokenSigningAlg: 'RS256' });
+  app.post('/followups', checkJwt, requiredScopes('create:followups'),
+    express.json({ limit: '4kb' }), (req, res) => {
+      const { incidentId, title } = req.body ?? {};
+      if (typeof incidentId !== 'string' || !incidentId.trim() || incidentId.length > 80 ||
+          typeof title !== 'string' || !title.trim() || title.length > 200) {
+        return res.status(400).json({ error: 'Provide incidentId (1–80 characters) and title (1–200 characters).' });
+      }
+      const record = { id: randomUUID(), incidentId: incidentId.trim(), title: title.trim(),
+        status: 'open', createdBy: req.auth.payload.sub, createdAt: new Date().toISOString() };
+      records.set(record.id, record);
+      res.status(201).json(record);
+    });
+  app.use((error, _req, res, _next) => {
+    const status = [400, 401, 403, 413, 415].includes(error.status) ? error.status : 500;
+    if (error.headers?.['WWW-Authenticate']) {
+      res.set('WWW-Authenticate', error.headers['WWW-Authenticate']);
+    }
+    res.status(status).json({ error: {
+      400: 'Invalid JSON body.', 401: 'A valid access token is required.',
+      403: 'The create:followups permission is required.', 413: 'Request body is too large.',
+      415: 'Unsupported request charset or content encoding.',
+      500: 'Unable to create follow-up.',
+    }[status] });
+  });
+  return app;
+}
+
+export function configuration(env, client = false) {
+  for (const name of ['AUTH0_DOMAIN', 'AUTH0_AUDIENCE',
+    ...(client ? ['AUTH0_CLIENT_ID', 'AUTH0_CLIENT_SECRET'] : [])]) {
+    if (!env[name]?.trim()) throw new Error(`Set ${name} before running this example.`);
+  }
+  if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$/i.test(env.AUTH0_DOMAIN)) {
+    throw new Error('AUTH0_DOMAIN must be a bare hostname, without https:// or a path.');
+  }
+  return { issuer: `https://${env.AUTH0_DOMAIN}/`, audience: env.AUTH0_AUDIENCE,
+    clientId: env.AUTH0_CLIENT_ID, clientSecret: env.AUTH0_CLIENT_SECRET };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const server = createApp(configuration(process.env)).listen(3101, '127.0.0.1', () => {
+      console.log('Auth0 follow-up API: http://127.0.0.1:3101/followups');
+    });
+    server.on('error', () => { console.error('Unable to listen on 127.0.0.1:3101.'); process.exitCode = 1; });
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/examples/auth0/test.mjs
+++ b/examples/auth0/test.mjs
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { once } from 'node:events';
+import { after, before, test } from 'node:test';
+import { exportJWK, generateKeyPair, SignJWT } from 'jose';
+import { createApp, configuration } from './server.mjs';
+import { runDemo } from './client.mjs';
+
+const audience = 'https://agents-everywhere.example/api';
+const records = new Map();
+let issuer, api, jwksServer, apiServer, privateKey;
+before(async () => {
+  const pair = await generateKeyPair('RS256');
+  privateKey = pair.privateKey;
+  const key = { ...await exportJWK(pair.publicKey), kid: 'test-key', alg: 'RS256', use: 'sig' };
+  jwksServer = createServer((req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(req.url.includes('.well-known')
+      ? { issuer, jwks_uri: `${issuer}jwks`, id_token_signing_alg_values_supported: ['RS256'] }
+      : { keys: [key] }));
+  }).listen(0, '127.0.0.1');
+  await once(jwksServer, 'listening');
+  issuer = `http://127.0.0.1:${jwksServer.address().port}/`;
+  apiServer = createApp({ issuer, audience, records })
+    .listen(0, '127.0.0.1');
+  await once(apiServer, 'listening');
+  api = `http://127.0.0.1:${apiServer.address().port}/followups`;
+});
+after(async () => {
+  await Promise.all([apiServer, jwksServer].filter(Boolean).map(server =>
+    new Promise(resolve => server.close(resolve))));
+});
+async function token(overrides = {}, key = privateKey) {
+  return new SignJWT({ scope: 'create:followups', ...overrides })
+    .setProtectedHeader({ alg: 'RS256', kid: 'test-key' })
+    .setIssuer(overrides.iss ?? issuer).setAudience(overrides.aud ?? audience)
+    .setSubject('hackathon-client@clients').setIssuedAt()
+    .setExpirationTime(overrides.exp ?? '5m').sign(key);
+}
+async function post(bearer, body = { incidentId: 'INC-1042', title: 'Investigate retry spike' }) {
+  return fetch(api, { method: 'POST', headers: {
+    'Content-Type': 'application/json', ...(bearer ? { Authorization: `Bearer ${bearer}` } : {}),
+  }, body: JSON.stringify(body) });
+}
+
+test('an authorized service creates an actual in-memory follow-up', async () => {
+  const response = await post(await token());
+  assert.equal(response.status, 201);
+  const record = await response.json();
+  assert.equal(record.incidentId, 'INC-1042');
+  assert.equal(record.status, 'open');
+  assert.equal(record.createdBy, 'hackathon-client@clients');
+  assert.deepEqual(records.get(record.id), record);
+});
+for (const [name, makeToken, expected] of [
+  ['missing bearer', async () => undefined, 401],
+  ['malformed JWT', async () => 'invalid.jwt', 401],
+  ['expired token', () => token({ exp: Math.floor(Date.now() / 1000) - 120 }), 401],
+  ['wrong audience', () => token({ aud: 'another-api' }), 401],
+  ['wrong issuer', () => token({ iss: 'https://another-issuer.example/' }), 401],
+  ['wrong signature', async () => token({}, (await generateKeyPair('RS256')).privateKey), 401],
+  ['missing permission', () => token({ scope: 'read:followups' }), 403],
+]) {
+  test(`${name} cannot create a follow-up`, async () => {
+    const count = records.size;
+    const response = await post(await makeToken());
+    assert.equal(response.status, expected);
+    assert.equal(records.size, count);
+  });
+}
+for (const body of [null, {}, { incidentId: 'INC-1', title: ' ' },
+  { incidentId: 42, title: 'Investigate' }, { incidentId: 'INC-1', title: 'x'.repeat(201) }]) {
+  test(`rejects invalid input ${JSON.stringify(body).slice(0, 70)}`, async () => {
+    const count = records.size;
+    assert.equal((await post(await token(), body)).status, 400);
+    assert.equal(records.size, count);
+  });
+}
+
+for (const [name, body, headers, expected, message] of [
+  ['malformed JSON', '{broken', {}, 400, 'Invalid JSON body.'],
+  ['oversized body', JSON.stringify({ title: 'x'.repeat(5000) }), {}, 413,
+    'Request body is too large.'],
+  ['unsupported charset', JSON.stringify({ incidentId: 'INC-1', title: 'Investigate' }),
+    { 'Content-Type': 'application/json; charset=iso-8859-1' }, 415,
+    'Unsupported request charset or content encoding.'],
+  ['unsupported content encoding', JSON.stringify({ incidentId: 'INC-1', title: 'Investigate' }),
+    { 'Content-Encoding': 'unsupported' }, 415,
+    'Unsupported request charset or content encoding.'],
+]) {
+  test(`${name} returns a sanitized client error and creates no records`, async () => {
+    const count = records.size;
+    const response = await fetch(api, { method: 'POST', headers: {
+      'Content-Type': 'application/json', Authorization: `Bearer ${await token()}`, ...headers,
+    }, body });
+    assert.equal(response.status, expected);
+    assert.deepEqual(await response.json(), { error: message });
+    assert.equal(records.size, count);
+  });
+}
+
+test('client obtains a token only after proving the API rejects anonymous actions', async () => {
+  const calls = [];
+  const record = { id: 'followup-1', status: 'open' };
+  const request = async (url, options) => {
+    calls.push({ url, options });
+    return [new Response(null, { status: 401 }),
+      Response.json({ access_token: 'fixture-token', token_type: 'Bearer' }),
+      Response.json(record, { status: 201 })][calls.length - 1];
+  };
+  assert.deepEqual(await runDemo({ issuer: 'https://tenant.example/', audience,
+    clientId: 'fixture-client', clientSecret: 'fixture-secret' }, request), record);
+  assert.equal(calls[0].options.headers.Authorization, undefined);
+  assert.equal(calls[1].url, 'https://tenant.example/oauth/token');
+  assert.equal(JSON.parse(calls[1].options.body).grant_type, 'client_credentials');
+  assert.equal(calls[2].options.headers.Authorization, 'Bearer fixture-token');
+  assert.equal(calls[2].options.redirect, 'error');
+});
+
+test('client stops when token issuance fails without exposing response details', async () => {
+  let calls = 0;
+  await assert.rejects(runDemo({ issuer: 'https://tenant.example/', audience,
+    clientId: 'fixture-client', clientSecret: 'fixture-secret' }, async () => {
+    calls++;
+    return calls === 1 ? new Response(null, { status: 401 }) :
+      new Response('sensitive response details', { status: 403 });
+  }), { message: 'Auth0 token request failed (HTTP 403); check your M2M API grant and credentials.' });
+  assert.equal(calls, 2);
+});
+
+test('configuration requires credentials and a bare domain', () => {
+  assert.throws(() => configuration({}), /Set AUTH0_DOMAIN/);
+  assert.throws(() => configuration({ AUTH0_DOMAIN: 'https:\/\/tenant.example',
+    AUTH0_AUDIENCE: audience }), /bare hostname/);
+  assert.throws(() => configuration({ AUTH0_DOMAIN: 'tenant.example',
+    AUTH0_AUDIENCE: audience }, true), /Set AUTH0_CLIENT_ID/);
+});

--- a/examples/mozilla/.gitignore
+++ b/examples/mozilla/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+__pycache__/
+traces/

--- a/examples/mozilla/README.md
+++ b/examples/mozilla/README.md
@@ -1,0 +1,80 @@
+# Mozilla.ai: show the context your agent actually used
+
+Use Mozilla.ai **any-agent** to run a small agent, inspect its tool execution, and save a trace you can show during your hackathon demo. This optional Python example reads a synthetic checkout incident, then produces an assessment with impact, uncertainty, and a next step. It illustrates the event's context theme: can you demonstrate that the agent consulted its surroundings?
+
+This is a standalone TinyAgent example. It does not instrument the starter kit's TypeScript agent, and neither Python nor these dependencies are part of npm startup.
+
+## Get access and configure
+
+any-agent is open source; no Mozilla account is needed. This recipe uses an OpenAI model, so obtain an API key and model access through [OpenAI's developer platform](https://platform.openai.com/api-keys). Model requests use your provider account's credits. Use the event's official instructions for any sponsor credits.
+
+Use **Python 3.11, 3.12, or 3.13**. The macOS system Python 3.9 is too old. From the repository root:
+
+```sh
+python3.12 -m venv examples/mozilla/.venv
+examples/mozilla/.venv/bin/python -m pip install -r examples/mozilla/requirements.txt
+```
+
+Substitute `python3.11` or `python3.13` if that is your installed supported interpreter. Configure `OPENAI_API_KEY` as an exported environment variable in your shell or secret manager before running. This recipe does **not** automatically load the repository's `.env` file, and it fails with an explicit setup error when the key is absent.
+
+The recipe pins `any-agent==1.18.0` and `mcp==1.30.0`: the former's MCP type imports are incompatible with MCP 2.x. The SDK installation and TinyAgent construction are covered by the offline checks below.
+
+## Run and see the result
+
+```sh
+examples/mozilla/.venv/bin/python examples/mozilla/trace_incident.py
+```
+
+The default model is `openai:gpt-4o-mini`. You can select another OpenAI model available to your account:
+
+```sh
+examples/mozilla/.venv/bin/python examples/mozilla/trace_incident.py --model openai:gpt-4o-mini
+```
+
+This focused recipe accepts OpenAI models only. Mozilla's Python model identifiers use `provider:model`; do not copy the starter kit's TypeScript provider syntax here. See [any-agent model configuration](https://mozilla-ai.github.io/any-agent/agents/models/) for extending it to other providers.
+
+Expect a model-generated assessment of `INC-1042`, three `PASS` lines, and a trace at `examples/mozilla/traces/incident.json`. Exact wording varies. A useful assessment mentions the checkout error increase, treats the nearby deployment as a possible cause, and asks the owner to compare logs before rollback. The agent only reads synthetic data; it does not change a real system.
+
+The trace inspector checks that:
+
+- A recorded **tool execution span** names `read_incident` and contains a JSON tool result with the fixture incident ID; failed dispatches and prose claiming a tool call are insufficient.
+- The final answer is nonempty text.
+- The final answer includes the incident ID.
+
+A failed check exits nonzero and preserves the trace for inspection. These are deterministic checks of observed behavior, **not a full evaluation of factual accuracy or safety**. Open the JSON and inspect the incident tool result and model response together. The default trace directory is gitignored; traces contain prompts and outputs, so review them before sharing if you replace the synthetic fixture with real data.
+
+## Verify offline
+
+After dependency installation, this uses no provider credentials or network calls:
+
+```sh
+examples/mozilla/.venv/bin/python -m unittest discover -s examples/mozilla -v
+```
+
+The suite runs TinyAgent with a fake key and a mocked provider, covering successful fixture reads and failed tool dispatches, and tests trace inspection with controlled trace-like objects. It rejects missing tools, planned calls, unrelated tools, invalid tool results, empty answers, and a wrong incident ID. It does not prove that a live model will call the tool; the live command performs that check on its actual trace.
+
+## Make it yours
+
+Edit `read_incident()` in [trace_incident.py](./trace_incident.py) to define your demo's surrounding context, then edit the instructions and prompt in `main()`. Keep synthetic records until you are ready to connect an authorized data source. Extend `inspect_trace()` with checks tied to your own demo's expected behavior.
+
+For a short demo: show the record, run the agent, show its assessment, then open the trace to demonstrate where that context entered the conversation.
+
+Reference: [Mozilla.ai first-agent cookbook](https://mozilla-ai.github.io/any-agent/cookbook/your-first-agent/), [tracing guide](https://mozilla-ai.github.io/any-agent/tracing/), and [evaluation cookbook](https://mozilla-ai.github.io/any-agent/cookbook/your-first-agent-evaluation/).
+
+### Execution budget
+
+The recipe allows at most **8 combined model calls and tool executions** per run.
+A callback checks the budget before either operation starts, including tools
+batched in one model response. Repeated tool requests and empty responses therefore
+terminate with exit code 1, an explicit error, and the partial trace saved at
+`--output`. A final answer on the last permitted step can still succeed.
+This limits agent steps, not dollars, tokens, or wall-clock duration.
+
+`execution_budget.py` uses the documented
+[any-agent callback cancellation API](https://mozilla-ai.github.io/any-agent/agents/callbacks/#using-agentcancel-recommended).
+The installed-SDK tests mock only the provider and cover repeated tool calls,
+empty responses, batched tools, and failure trace export without credentials:
+
+```bash
+python -m unittest discover -s examples/mozilla -p 'test_*.py' -v
+```

--- a/examples/mozilla/execution_budget.py
+++ b/examples/mozilla/execution_budget.py
@@ -1,0 +1,36 @@
+"""Bound TinyAgent execution using any-agent 1.18.0's callback API."""
+
+from any_agent import AgentCancel
+from any_agent.callbacks import Callback
+from any_agent.callbacks.context import Context
+
+MAX_STEPS = 8
+
+
+class StepBudgetExceeded(AgentCancel):
+    """The recipe exhausted its combined model-call and tool-execution budget."""
+
+
+class StepBudget(Callback):
+    """Count before execution so no model or tool runs beyond the budget."""
+
+    def __init__(self, max_steps: int = MAX_STEPS):
+        if max_steps < 1:
+            raise ValueError("max_steps must be positive")
+        self.max_steps = max_steps
+
+    def _consume(self, context: Context) -> Context:
+        steps = context.shared.get("incident_recipe_steps", 0)
+        if steps >= self.max_steps:
+            raise StepBudgetExceeded(
+                f"Stopped after {self.max_steps} model/tool steps without a final answer. "
+                "Inspect the partial trace for repeated tool calls or empty responses."
+            )
+        context.shared["incident_recipe_steps"] = steps + 1
+        return context
+
+    def before_llm_call(self, context: Context, *args, **kwargs) -> Context:
+        return self._consume(context)
+
+    def before_tool_execution(self, context: Context, *args, **kwargs) -> Context:
+        return self._consume(context)

--- a/examples/mozilla/requirements.txt
+++ b/examples/mozilla/requirements.txt
@@ -1,0 +1,3 @@
+any-agent==1.18.0
+# any-agent 1.18.0 imports MCP 1.x types removed in MCP 2.x.
+mcp==1.30.0

--- a/examples/mozilla/test_sdk.py
+++ b/examples/mozilla/test_sdk.py
@@ -1,0 +1,153 @@
+"""Installed SDK smoke test. Creates the agent without calling a provider."""
+
+import contextlib
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from any_llm.types.completion import ChatCompletion
+
+from execution_budget import StepBudget, StepBudgetExceeded
+
+from any_agent import AgentConfig, AnyAgent
+
+from trace_incident import INCIDENT_ID, inspect_trace, main, read_incident
+
+
+class InstalledSdkTests(unittest.TestCase):
+    def test_tinyagent_accepts_fixture_tool(self):
+        agent = AnyAgent.create(
+            "tinyagent",
+            AgentConfig(
+                model_id="openai:gpt-4o-mini",
+                api_key="offline-test-key",
+                tools=[read_incident],
+            ),
+        )
+        self.assertEqual(agent.config.model_id, "openai:gpt-4o-mini")
+        self.assertTrue(any(tool.__name__ == "read_incident" for tool in agent.config.tools))
+
+
+    def run_incident_provider(self, arguments: str):
+        responses = [
+            ChatCompletion(
+                id="offline-tool", created=0, model="gpt-4o-mini",
+                object="chat.completion",
+                choices=[{"index": 0, "finish_reason": "tool_calls", "message": {
+                    "role": "assistant", "content": None,
+                    "tool_calls": [{"id": "call_incident", "type": "function",
+                                    "function": {"name": "read_incident", "arguments": arguments}}],
+                }}],
+            ),
+            ChatCompletion(
+                id="offline-answer", created=0, model="gpt-4o-mini",
+                object="chat.completion",
+                choices=[{"index": 0, "finish_reason": "stop", "message": {
+                    "role": "assistant", "content": f"{INCIDENT_ID}: I read the incident.",
+                }}],
+            ),
+        ]
+        agent = AnyAgent.create(
+            "tinyagent",
+            AgentConfig(model_id="openai:gpt-4o-mini", api_key="offline-test-key",
+                        tools=[read_incident], callbacks=[StepBudget()]),
+        )
+        with patch.object(agent.llm, "acompletion", new=AsyncMock(side_effect=responses)) as provider:
+            trace = agent.run("Read the incident")
+        self.assertEqual(provider.await_count, 2)
+        spans = [span for span in trace.spans if span.is_tool_execution()]
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].attributes["gen_ai.tool.name"], "read_incident")
+        return trace, spans[0].attributes["gen_ai.output"]
+
+    def test_failed_dispatch_is_not_incident_evidence(self):
+        trace, output = self.run_incident_provider('{"unexpected":"argument"}')
+        self.assertIn("Error calling tool:", output)
+        self.assertFalse(inspect_trace(trace)["read_incident_executed"])
+        self.assertTrue(inspect_trace(trace)["incident_id_in_output"])
+
+    def test_successful_fixture_output_is_incident_evidence(self):
+        trace, output = self.run_incident_provider("{}")
+        self.assertEqual(json.loads(output)["id"], INCIDENT_ID)
+        self.assertTrue(all(inspect_trace(trace).values()))
+
+
+class ExecutionBudgetTests(unittest.TestCase):
+    def run_repeating_provider(self, tool_count: int):
+        executions = []
+
+        def read_incident() -> str:
+            """Read the test incident."""
+            executions.append("read")
+            return "INC-1042"
+
+        message = {"role": "assistant", "content": None}
+        if tool_count:
+            message["tool_calls"] = [
+                {"id": f"call_{index}", "type": "function",
+                 "function": {"name": "read_incident", "arguments": "{}"}}
+                for index in range(tool_count)
+            ]
+        response = ChatCompletion(
+            id="offline-completion", created=0, model="gpt-4o-mini",
+            object="chat.completion",
+            choices=[{"index": 0, "finish_reason": "tool_calls" if tool_count else "stop",
+                      "message": message}],
+        )
+        agent = AnyAgent.create(
+            "tinyagent",
+            AgentConfig(model_id="openai:gpt-4o-mini", api_key="offline-test-key",
+                        tools=[read_incident], callbacks=[StepBudget(max_steps=8)]),
+        )
+        # Exercise the real SDK loop and callback wrappers, mocking only the provider.
+        with patch.object(agent.llm, "acompletion", new=AsyncMock(return_value=response)) as provider:
+            with self.assertRaises(StepBudgetExceeded) as caught:
+                agent.run("Read the incident")
+        self.assertIsNotNone(caught.exception.trace)
+        self.assertTrue(caught.exception.trace.spans)
+        self.assertIn("8 model/tool steps", str(caught.exception))
+        return provider.await_count, len(executions)
+
+    def test_cli_exhaustion_fails_and_exports_partial_trace(self):
+        response = ChatCompletion(
+            id="offline-empty", created=0, model="gpt-4o-mini",
+            object="chat.completion",
+            choices=[{"index": 0, "finish_reason": "stop",
+                      "message": {"role": "assistant", "content": None}}],
+        )
+        agent = AnyAgent.create(
+            "tinyagent",
+            AgentConfig(model_id="openai:gpt-4o-mini", api_key="offline-test-key"),
+        )
+        errors = io.StringIO()
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "partial.json"
+            with (
+                patch.object(type(agent.llm), "acompletion", new=AsyncMock(return_value=response)) as provider,
+                patch.dict(os.environ, {"OPENAI_API_KEY": "offline-test-key"}),
+                patch("sys.argv", ["trace_incident.py", "--output", str(output)]),
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(errors),
+            ):
+                self.assertEqual(main(), 1)
+            self.assertEqual(provider.await_count, 8)
+            self.assertTrue(json.loads(output.read_text())["spans"])
+            self.assertNotIn("offline-test-key", output.read_text())
+        self.assertIn("ERROR: Stopped after 8 model/tool steps", errors.getvalue())
+
+    def test_repeated_tool_calls_stop_before_ninth_step(self):
+        self.assertEqual(self.run_repeating_provider(tool_count=1), (4, 4))
+
+    def test_empty_responses_stop_before_ninth_model_call(self):
+        self.assertEqual(self.run_repeating_provider(tool_count=0), (8, 0))
+
+    def test_batched_tools_cannot_execute_beyond_budget(self):
+        self.assertEqual(self.run_repeating_provider(tool_count=12), (1, 7))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/mozilla/test_trace_incident.py
+++ b/examples/mozilla/test_trace_incident.py
@@ -1,0 +1,60 @@
+"""Offline checks: a claimed tool call must not pass as an executed span."""
+
+import json
+import unittest
+from dataclasses import dataclass, field
+
+from trace_incident import INCIDENT_ID, inspect_trace, read_incident
+
+
+@dataclass
+class FakeSpan:
+    executed: bool
+    attributes: dict = field(default_factory=dict)
+
+    def is_tool_execution(self):
+        return self.executed
+
+
+@dataclass
+class FakeTrace:
+    spans: list
+    final_output: object
+
+
+class TraceInspectionTests(unittest.TestCase):
+    def test_tool_execution_and_output_pass(self):
+        trace = FakeTrace([FakeSpan(True, {"gen_ai.tool.name": "read_incident", "gen_ai.output": read_incident()})], f"{INCIDENT_ID}: investigating")
+        self.assertTrue(all(inspect_trace(trace).values()))
+
+    def test_claimed_or_planned_tool_call_does_not_pass(self):
+        for spans in ([], [FakeSpan(False, {"gen_ai.tool.name": "read_incident"})], [FakeSpan(True, {"gen_ai.tool.name": "other"})]):
+            with self.subTest(spans=spans):
+                trace = FakeTrace(spans, f"I called read_incident for {INCIDENT_ID}")
+                self.assertFalse(inspect_trace(trace)["read_incident_executed"])
+
+    def test_missing_failed_or_wrong_tool_result_does_not_pass(self):
+        for output in (None, "", "Error calling tool: dispatch failed", "null", "[]",
+                       json.dumps({"id": "INC-9999"}), {"id": INCIDENT_ID}):
+            with self.subTest(output=output):
+                trace = FakeTrace([FakeSpan(True, {
+                    "gen_ai.tool.name": "read_incident", "gen_ai.output": output,
+                })], f"I read {INCIDENT_ID}")
+                self.assertFalse(inspect_trace(trace)["read_incident_executed"])
+
+    def test_missing_output_and_wrong_incident_fail(self):
+        for output in (None, "", "   ", {"id": INCIDENT_ID}):
+            with self.subTest(output=output):
+                self.assertFalse(inspect_trace(FakeTrace([], output))["nonempty_text_output"])
+        self.assertFalse(inspect_trace(FakeTrace([], "INC-9999"))["incident_id_in_output"])
+
+    def test_fixture_is_synthetic_and_preserves_uncertainty(self):
+        incident = json.loads(read_incident())
+        self.assertTrue(incident["synthetic"])
+        self.assertEqual(incident["id"], INCIDENT_ID)
+        self.assertTrue(incident["observations"])
+        self.assertTrue(incident["unknowns"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/mozilla/trace_incident.py
+++ b/examples/mozilla/trace_incident.py
@@ -1,0 +1,121 @@
+"""Trace an agent reading a synthetic incident with Mozilla.ai any-agent."""
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+from typing import Protocol, Sequence
+
+INCIDENT_ID = "INC-1042"
+
+
+def read_incident() -> str:
+    """Read the synthetic incident record, including evidence and uncertainty."""
+    return json.dumps({
+        "synthetic": True,
+        "id": INCIDENT_ID,
+        "service": "checkout",
+        "status": "investigating",
+        "observations": [
+            "14:02 UTC: checkout errors rose from 0.2% to 8%.",
+            "14:00 UTC: release checkout-2026.09.09.1 completed.",
+            "14:05 UTC: database latency remained within its normal range.",
+        ],
+        "unknowns": ["Whether the release caused the errors."],
+        "allowed_next_step": "Ask the incident owner to compare release error logs before approving rollback.",
+    })
+
+
+class Span(Protocol):
+    attributes: dict
+
+    def is_tool_execution(self) -> bool: ...
+
+
+class Trace(Protocol):
+    spans: Sequence[Span]
+    final_output: object
+
+
+def is_incident_result(span: Span) -> bool:
+    """Require the fixture result; the SDK also traces failed tool dispatches."""
+    if not span.is_tool_execution() or span.attributes.get("gen_ai.tool.name") != "read_incident":
+        return False
+    output = span.attributes.get("gen_ai.output")
+    if not isinstance(output, str):
+        return False
+    try:
+        incident = json.loads(output)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(incident, dict) and incident.get("id") == INCIDENT_ID
+
+
+def inspect_trace(trace: Trace) -> dict[str, bool]:
+    """Check recorded behavior, not whether the model's reasoning is correct."""
+    output = trace.final_output
+    return {
+        "read_incident_executed": any(is_incident_result(span) for span in trace.spans),
+        "nonempty_text_output": isinstance(output, str) and bool(output.strip()),
+        "incident_id_in_output": isinstance(output, str) and INCIDENT_ID in output,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="openai:gpt-4o-mini")
+    parser.add_argument("--output", type=Path, default=Path(__file__).parent / "traces" / "incident.json")
+    args = parser.parse_args()
+    if not (3, 11) <= sys.version_info[:2] < (3, 14):
+        parser.error("Use Python 3.11, 3.12, or 3.13 for any-agent 1.18.0.")
+    if not args.model.startswith("openai:") or not args.model.removeprefix("openai:").strip():
+        parser.error("This recipe supports OpenAI models: --model openai:MODEL_NAME.")
+    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if not api_key:
+        parser.error("Export OPENAI_API_KEY before running; root .env is not loaded by this optional recipe.")
+
+    from any_agent import AgentConfig, AnyAgent
+
+    from execution_budget import StepBudget, StepBudgetExceeded
+
+    agent = AnyAgent.create(
+        "tinyagent",
+        AgentConfig(
+            model_id=args.model,
+            api_key=api_key,
+            instructions=(
+                "Call read_incident before answering. Summarize the incident with its ID, "
+                "observed impact, uncertainty, and one suggested next step. Distinguish "
+                "correlation from cause. Do not claim to have performed a rollback."
+            ),
+            tools=[read_incident],
+            callbacks=[StepBudget()],
+        ),
+    )
+    exhausted = False
+    try:
+        trace = agent.run("Read the incident and prepare a short assessment for its owner.")
+    except StepBudgetExceeded as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        exhausted = True
+        trace = error.trace
+        if trace is None:
+            print("No partial trace was available.", file=sys.stderr)
+            return 1
+    # Keep credentials out of the exported artifact even if a future SDK serializes config.
+    serialized = trace.model_dump_json(indent=2, serialize_as_any=True)
+    serialized = serialized.replace(api_key, "[REDACTED]")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(serialized + "\n", encoding="utf-8")
+    print(str(trace.final_output).replace(api_key, "[REDACTED]"))
+    checks = inspect_trace(trace)
+    print("\nTrace checks (observed behavior only):")
+    for name, passed in checks.items():
+        print(f"  {'PASS' if passed else 'FAIL'} {name}")
+    print(f"Trace saved: {args.output}")
+    return 0 if not exhausted and all(checks.values()) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "dev:local": "npm run dev --workspace local-chat",
     "dev:web": "npm run dev --workspace web",
     "dev:mcp": "npm run dev --workspace mcp",
-    "test": "npm run test --workspaces --if-present",
-    "test:watch": "vitest",
+    "test": "node --import tsx --test scripts/check-env.test.ts scripts/verify.test.mjs && npm run test --workspaces --if-present",
     "verify": "bash scripts/verify.sh"
   },
   "overrides": {

--- a/packages/agent-core/src/model.ts
+++ b/packages/agent-core/src/model.ts
@@ -1,40 +1,61 @@
-/**
- * Model resolution.
- *
- * Defaults to OpenAI (marquee sponsor) on `gpt-5.6-sol`, with `gpt-6-astra` one
- * env var away. Setting OPENROUTER_API_KEY flips the whole kit onto
- * OpenRouter with no other change — that is your insurance if OpenAI
- * rate-limits you at 14:00 with the demo at 15:30.
- *
- * Verified against @copilotkit/runtime@1.70.1: `BuiltInAgent` accepts either a
- * `"provider/model"` string or an AI SDK `LanguageModel` instance, and its
- * internal resolver normalises `/` and `:` to the same thing.
- */
+/** Resolve the selected chat provider. Voice uses OpenAI Realtime separately. */
 import { createOpenAI } from "@ai-sdk/openai";
 import { DEFAULT_MODEL } from "./model-meta";
 
-export function resolveModel() {
-  const model = (process.env.MODEL ?? DEFAULT_MODEL).trim();
-  const openRouterKey = process.env.OPENROUTER_API_KEY;
+function canonicalProvider(provider: string) {
+  const normalized = provider.trim().toLowerCase();
+  return normalized === "gemini" || normalized === "google-gemini" ? "google" : normalized;
+}
 
-  if (openRouterKey) {
-    // OpenRouter is OpenAI-compatible, so the AI SDK's OpenAI provider drives it
-    // directly. We build a LanguageModel rather than passing a string, because
-    // the runtime's string resolver would eat the `openai/` half of an
-    // OpenRouter slug as the provider name.
+export function resolveModel() {
+  const model = (process.env.MODEL || DEFAULT_MODEL).trim();
+  const firstSeparator = model.search(/[:/]/);
+  const candidatePrefix = firstSeparator >= 0 ? canonicalProvider(model.slice(0, firstSeparator)) : undefined;
+  // A colon in a bare model name can introduce a variant, such as ':free'.
+  // Only supported provider prefixes use colon syntax; publishers use '/'.
+  const separator = firstSeparator >= 0 && (model[firstSeparator] === "/" ||
+    ["openai", "openrouter", "anthropic", "google"].includes(candidatePrefix || ""))
+    ? firstSeparator : -1;
+  const prefix = separator >= 0 ? candidatePrefix : undefined;
+  const modelId = separator >= 0 ? model.slice(separator + 1).trim() : model;
+  if (!modelId) {
+    throw new Error("MODEL must include a non-empty model identifier.");
+  }
+  // Preserve the original automatic router switch for existing .env files.
+  const provider = canonicalProvider(process.env.MODEL_PROVIDER || "") ||
+    (process.env.OPENROUTER_API_KEY ? "openrouter" : prefix || "openai");
+  const keyNames: { [provider: string]: string | undefined } = {
+    openai: "OPENAI_API_KEY",
+    openrouter: "OPENROUTER_API_KEY",
+    anthropic: "ANTHROPIC_API_KEY",
+    google: "GOOGLE_API_KEY",
+  };
+  const keyName = Object.hasOwn(keyNames, provider) ? keyNames[provider] : undefined;
+  if (!keyName) {
+    throw new Error(`Unsupported model provider '${provider}'. Set MODEL_PROVIDER to openai, openrouter, anthropic, or google.`);
+  }
+  if (provider !== "openrouter" && prefix && prefix !== provider) {
+    throw new Error(`MODEL provider '${prefix}' does not match MODEL_PROVIDER '${provider}'.`);
+  }
+  const apiKey = process.env[keyName];
+  if (!apiKey || apiKey === "stub-replace-me") {
+    throw new Error(`${keyName} is required for ${provider}. Run npm run check-env.`);
+  }
+
+  if (provider === "openrouter") {
     const openRouter = createOpenAI({
       baseURL: "https://openrouter.ai/api/v1",
-      apiKey: openRouterKey,
-      // Attribution headers put your build on OpenRouter's public rankings.
+      apiKey,
       headers: {
         "HTTP-Referer": process.env.PUBLIC_APP_URL ?? "https://aitinkerers.org",
         "X-OpenRouter-Title": process.env.APP_TITLE ?? "Agents, Everywhere",
       },
     });
-    return openRouter(model.includes("/") ? model : `openai/${model}`);
+    // Change only a provider separator; keep suffixes such as ':free' intact.
+    const slug = `${prefix || "openai"}/${modelId}`;
+    // AI SDK OpenAI v3 defaults to /responses. OpenRouter uses /chat/completions.
+    return openRouter.chat(slug);
   }
 
-  // A value that already names a provider passes through untouched, so you can
-  // set MODEL=anthropic/claude-sonnet-4-6 or google/gemini-2.5-flash instead.
-  return model.includes(":") || model.includes("/") ? model : `openai:${model}`;
+  return `${provider}:${modelId}`;
 }

--- a/packages/agent-core/src/prompt.ts
+++ b/packages/agent-core/src/prompt.ts
@@ -43,13 +43,17 @@ How to work an incident:
   seconds beats three paragraphs. Update it as things change.
 - **Keep a timeline.** Call timeline when there are three or more events worth
   ordering. On-call handover and the postmortem both run on it.
-- **Never touch production without a click.** Restarting, scaling, rolling back,
-  failing over, clearing a queue, paging someone: call propose_action and wait.
-  An outage is exactly when people feel entitled to skip this, and exactly when
-  skipping it makes things worse.
-- **Hand slow work to the worker.** Anything that takes minutes — trawling logs,
-  diffing deploys, gathering diagnostics — goes to run_deep_work so the thread
-  stays usable while it runs.
+- **Production actions are proposals only in this demo.** Restarting, scaling,
+  rolling back, failing over, clearing a queue, paging someone: call
+  propose_action and stop. Its result is pending, not approval. Do not call write
+  tools to perform the proposal. A click records a decision only; it executes
+  nothing and does not automatically resume you.
+- **Delegate public-web research after approval.** Use run_deep_work for Exa
+  research of public sources. It cannot access internal logs, inspect deploys,
+  gather private diagnostics, or execute actions; say so when those are needed.
+  Results are not pushed automatically. Give the user the run ID and explain
+  that they must ask you to check it with check_deep_work to receive results in
+  this thread.
 - **Ground your claims.** If you are asked about an error message, a dependency,
   or a third-party status, call search_web rather than guessing. In an incident a
   confident wrong answer costs more than "I don't know".

--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -25,19 +25,69 @@ fi
 
 # ── .env ─────────────────────────────────────────────────────────────────────
 if [ ! -f .env ]; then
-  fail ".env is missing. Run: cp .env.example .env   then fill in OPENAI_API_KEY."
+  fail ".env is missing. Run: cp .env.example .env   then choose MODEL_PROVIDER and fill in its API key."
 else
   set -a; . ./.env; set +a
 fi
 
+# Keep provider/model normalization aligned with agent-core/src/model.ts.
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+canonical_provider() {
+  local value
+  value="$(trim "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$value" in gemini|google-gemini) value=google ;; esac
+  printf '%s' "$value"
+}
+
 # ── tier 0 ───────────────────────────────────────────────────────────────────
 if [ -f .env ]; then
-  case "${OPENAI_API_KEY:-}" in
-    "")                 fail "OPENAI_API_KEY is empty. Get one: https://platform.openai.com/api-keys" ;;
-    stub-replace-me)    fail "OPENAI_API_KEY is still the placeholder. Get one: https://platform.openai.com/api-keys" ;;
-    sk-*)               ;;
-    *)                  warn "OPENAI_API_KEY does not start with 'sk-'. If you are proxying through a gateway, ignore this." ;;
+  model="$(trim "${MODEL:-gpt-5.6-sol}")"
+  model_id="$model"
+  model_provider=""
+  case "$model" in
+    *[:/]*) candidate_prefix="$(canonical_provider "${model%%[:/]*}")"
+             # A bare model's ':free' or ':nitro' suffix is not a provider.
+             case "$model" in
+               "${model%%[:/]*}/"*) model_provider="$candidate_prefix" ;;
+               *) case "$candidate_prefix" in
+                    openai|openrouter|anthropic|google) model_provider="$candidate_prefix" ;;
+                  esac ;;
+             esac
+             [ -n "$model_provider" ] && model_id="$(trim "${model#*[:/]}")" ;;
   esac
+  [ -z "$model_id" ] && fail "MODEL must include a non-empty model identifier."
+  provider="$(canonical_provider "${MODEL_PROVIDER:-}")"
+  if [ -z "$provider" ]; then
+    if [ -n "${OPENROUTER_API_KEY:-}" ]; then provider=openrouter
+    else provider="${model_provider:-openai}"; fi
+  fi
+  key_name=""
+  case "$provider" in
+    openai) key_name=OPENAI_API_KEY ;;
+    openrouter) key_name=OPENROUTER_API_KEY ;;
+    anthropic) key_name=ANTHROPIC_API_KEY ;;
+    google) key_name=GOOGLE_API_KEY ;;
+    *) fail "Unsupported model provider '$provider'. Set MODEL_PROVIDER to openai, openrouter, anthropic, or google." ;;
+  esac
+  if [ "$provider" != openrouter ] && [ -n "$model_provider" ] && [ "$model_provider" != "$provider" ]; then
+    fail "MODEL provider '$model_provider' does not match MODEL_PROVIDER '$provider'."
+  fi
+  if [ -n "$key_name" ]; then
+    case "${!key_name:-}" in
+      "") fail "$key_name is empty. Configure credentials for $provider." ;;
+      stub-replace-me) fail "$key_name is still the placeholder. Configure credentials for $provider." ;;
+    esac
+  fi
+  if [ "${1:-}" = --voice ]; then
+    case "${OPENAI_API_KEY:-}" in
+      ""|stub-replace-me) fail "OPENAI_API_KEY is required separately for OpenAI Realtime voice, even when chat uses $provider." ;;
+    esac
+  fi
   [ -z "${MODEL:-}" ] && warn "MODEL is unset; falling back to gpt-5.6-sol."
 
   # ── tier 1: all-or-nothing. Half-configured Channels is the worst state. ──

--- a/scripts/check-env.test.ts
+++ b/scripts/check-env.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+function preflight(config: string, args: string[] = [] as const) {
+  const root = mkdtempSync(join(tmpdir(), "agents-env-"));
+  try {
+    mkdirSync(join(root, "scripts"));
+    mkdirSync(join(root, "node_modules/@copilotkit/channels"), { recursive: true });
+    copyFileSync(new URL("./check-env.sh", import.meta.url), join(root, "scripts/check-env.sh"));
+    writeFileSync(join(root, ".env"), config);
+    return spawnSync("bash", [join(root, "scripts/check-env.sh"), ...args], {
+      encoding: "utf8", env: { PATH: process.env.PATH },
+    });
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+for (const config of [
+  "OPENROUTER_API_KEY=sk-or-test\nMODEL=openai/gpt-test",
+  "MODEL_PROVIDER=openrouter\nOPENROUTER_API_KEY=sk-or-test\nOPENAI_API_KEY=stub-replace-me",
+  "MODEL_PROVIDER=openai\nOPENAI_API_KEY=sk-test\nOPENROUTER_API_KEY=stub-replace-me",
+  "MODEL=anthropic/claude-test\nANTHROPIC_API_KEY=sk-test",
+  "MODEL=google:gemini-test\nGOOGLE_API_KEY=test",
+] as const) {
+  test(`validates only selected provider: ${config.split("\n")[0]}`, () => {
+    const result = preflight(config);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  });
+}
+for (const [config, error] of [
+  ["MODEL_PROVIDER=openrouter\nOPENAI_API_KEY=sk-test", /OPENROUTER_API_KEY is empty/],
+  ["MODEL_PROVIDER=openai\nOPENROUTER_API_KEY=sk-or-test", /OPENAI_API_KEY is empty/],
+  ["MODEL_PROVIDER=invalid\nOPENAI_API_KEY=sk-test", /Unsupported.*MODEL_PROVIDER/],
+  ["MODEL=invalid/model\nOPENAI_API_KEY=sk-test", /Unsupported.*provider/],
+  ["MODEL_PROVIDER=openai\nMODEL=anthropic/claude-test\nOPENAI_API_KEY=sk-test", /does not match/],
+] as const) {
+  test(`rejects invalid configuration: ${config.split("\n")[0]} ${error}`, () => {
+    const result = preflight(config);
+    assert.equal(result.status, 1);
+    assert.match(result.stdout, error);
+  });
+}
+test("voice separately requires an OpenAI credential", () => {
+  const result = preflight("OPENROUTER_API_KEY=sk-or-test", ["--voice"]);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /OPENAI_API_KEY.*voice/);
+});
+
+function modelConfig(config: NodeJS.ProcessEnv) {
+  return spawnSync(process.execPath, ["--import", "tsx", "--input-type=module", "-e", `
+    import { resolveModel } from './packages/agent-core/src/model.ts';
+    const model = resolveModel();
+    console.log(JSON.stringify(typeof model === 'string' ? model : { modelId: model.modelId, provider: model.provider }));
+  `], { encoding: "utf8", env: { PATH: process.env.PATH, ...config } });
+}
+
+test("explicit OpenAI wins over a configured router key", () => {
+  const result = modelConfig({ MODEL_PROVIDER: "openai", OPENAI_API_KEY: "sk-test", OPENROUTER_API_KEY: "sk-or-test", MODEL: "gpt-test" });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout), "openai:gpt-test");
+});
+for (const [input, expected] of [
+  ["openai:gpt-test", "openai/gpt-test"],
+  ["openai/gpt-test", "openai/gpt-test"],
+  ["meta-llama/llama-test:free", "meta-llama/llama-test:free"],
+  ["gpt-test:free", "openai/gpt-test:free"],
+  ["gpt-test:nitro", "openai/gpt-test:nitro"],
+  ["openai:gpt-test:free", "openai/gpt-test:free"],
+  ["OpenAI:gpt-test:free", "openai/gpt-test:free"],
+  ["OpenAI/gpt-test:free", "openai/gpt-test:free"],
+  ["Google:gemini-test:free", "google/gemini-test:free"],
+  ["Gemini:gemini-test:free", "google/gemini-test:free"],
+  ["Google-Gemini:gemini-test:free", "google/gemini-test:free"],
+  ["gpt-test", "openai/gpt-test"],
+] as const) {
+  test(`OpenRouter uses chat completions and preserves slug: ${input}`, () => {
+    for (const provider of [undefined, "openrouter", " OpenRouter "]) {
+      const config = { OPENROUTER_API_KEY: "sk-or-test", MODEL: input,
+        ...(provider ? { MODEL_PROVIDER: provider } : {}) };
+      const check = preflight(envFile(config));
+      const result = modelConfig(config);
+      assert.equal(check.status, 0, check.stdout + check.stderr);
+      assert.equal(result.status, 0, result.stderr);
+      assert.deepEqual(JSON.parse(result.stdout), { modelId: expected, provider: "openai.chat" });
+    }
+  });
+}
+for (const [config, error] of [
+  [{ MODEL_PROVIDER: "openrouter", OPENAI_API_KEY: "sk-test" }, /OPENROUTER_API_KEY/],
+  [{ MODEL_PROVIDER: "invalid" }, /Unsupported/],
+  [{ MODEL_PROVIDER: "openai", MODEL: "anthropic/claude-test", OPENAI_API_KEY: "sk-test" }, /does not match/],
+] as const) {
+  test(`model resolver rejects invalid config: ${JSON.stringify(config)}`, () => {
+    const result = modelConfig(config);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, error);
+  });
+}
+
+// Exercise identical .env values through preflight and the runtime resolver.
+function envFile(config: NodeJS.ProcessEnv) {
+  return Object.entries(config).map(([key, value]) => `${key}='${value}'`).join("\n");
+}
+const aliases = ["google", "gemini", "google-gemini"] as const;
+for (const provider of aliases) {
+  for (const prefix of aliases) {
+    test(`Google aliases agree: ${provider} / ${prefix}`, () => {
+      const config = { MODEL_PROVIDER: provider, MODEL: `${prefix}:gemini-test`, GOOGLE_API_KEY: "test" };
+      const check = preflight(envFile(config));
+      const runtime = modelConfig(config);
+      assert.equal(check.status, 0, check.stdout + check.stderr);
+      assert.equal(runtime.status, 0, runtime.stderr);
+      assert.equal(JSON.parse(runtime.stdout), "google:gemini-test");
+    });
+  }
+}
+for (const config of [
+  { MODEL: "OpenAI:gpt-test", OPENAI_API_KEY: "test" },
+  { MODEL: " openai/gpt-test ", OPENAI_API_KEY: "test" },
+  { MODEL: " openai/gpt-test ", MODEL_PROVIDER: "openai", OPENAI_API_KEY: "test" },
+  { MODEL: "OpenAI/gpt-test", MODEL_PROVIDER: " OpenAI ", OPENAI_API_KEY: "test" },
+]) {
+  test(`normalizes provider configuration: ${JSON.stringify(config)}`, () => {
+    const check = preflight(envFile(config));
+    const runtime = modelConfig(config);
+    assert.equal(check.status, 0, check.stdout + check.stderr);
+    assert.equal(runtime.status, 0, runtime.stderr);
+    assert.equal(JSON.parse(runtime.stdout), "openai:gpt-test");
+  });
+}
+for (const provider of ["openai", "openrouter"]) {
+  for (const model of ["   ", "openai:", "openai/", "openai:   "]) {
+    test(`rejects empty model ID: ${provider} ${JSON.stringify(model)}`, () => {
+      const config = { MODEL_PROVIDER: provider, MODEL: model, OPENAI_API_KEY: "test", OPENROUTER_API_KEY: "test" };
+      const check = preflight(envFile(config));
+      const runtime = modelConfig(config);
+      assert.equal(check.status, 1, check.stdout + check.stderr);
+      assert.match(check.stdout, /MODEL must include a non-empty model identifier/);
+      assert.notEqual(runtime.status, 0);
+      assert.match(runtime.stderr, /MODEL must include a non-empty model identifier/);
+    });
+  }
+}

--- a/scripts/verify-mcp.mjs
+++ b/scripts/verify-mcp.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+/** Exercise the production stdio entry point. No ports, temp files, or credentials. */
+export async function verifyMcp({
+  transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["--import", "tsx", "apps/mcp/src/stdio.ts"],
+    cwd: fileURLToPath(new URL("../", import.meta.url)),
+    env: {},
+    stderr: "inherit",
+  }),
+  timeoutMs = 15000,
+} = {}) {
+  const client = new Client({ name: "offline-verifier", version: "1" });
+  let timer;
+  let interrupted;
+  const interruption = new Promise((_, reject) => {
+    interrupted = (signal) => reject(new Error(`MCP verification interrupted by ${signal}`));
+    timer = setTimeout(() => reject(new Error(`MCP verification timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  const onInt = () => interrupted("SIGINT");
+  const onTerm = () => interrupted("SIGTERM");
+  process.on("SIGINT", onInt);
+  process.on("SIGTERM", onTerm);
+  try {
+    await Promise.race([
+      interruption,
+      (async () => {
+        await client.connect(transport);
+        assert.ok(client.getServerVersion(), "initialize must return server identity");
+        const { tools } = await client.listTools();
+        const card = tools.find((tool) => tool.name === "incident_card");
+        assert.ok(card, "tools/list must expose incident_card");
+        assert.equal(card._meta?.["openai/outputTemplate"], "ui://widget/incident-card.html");
+        const result = await client.callTool({
+          name: "incident_card",
+          arguments: { headline: "Checkout latency above 4s", summary: "~12% of checkouts, EU" },
+        });
+        assert.ok(!result.isError, "incident_card must succeed");
+        assert.equal(result.structuredContent?.headline, "Checkout latency above 4s");
+        const resource = await client.readResource({ uri: "ui://widget/incident-card.html" });
+        assert.ok(resource.contents.some((item) => typeof item.text === "string" && item.text.includes("window.openai")),
+          "widget must serve the OpenAI bridge");
+      })(),
+    ]);
+  } finally {
+    clearTimeout(timer);
+    // The SDK closes stdin, then escalates to SIGTERM/SIGKILL only for this child.
+    // Close the transport directly even if initialization failed partway through.
+    try {
+      await transport.close();
+    } finally {
+      process.removeListener("SIGINT", onInt);
+      process.removeListener("SIGTERM", onTerm);
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await verifyMcp();
+    console.log("  initialize · tools/list · incident_card · widget resource passed");
+  } catch (error) {
+    console.error("MCP verification failed:", error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Everything that can be proven without a credential.
 #
-# Deliberately not a smoke test: it typechecks every surface, runs the component
+# Deliberately not a smoke test: it typechecks the root workspaces, runs the component
 # and safety tests, and drives the MCP server over the real protocol. What it
 # cannot do is prove the Slack round trip — that needs your own Intelligence
 # project, and it says so at the end rather than implying otherwise.
@@ -14,47 +14,19 @@ ok()   { printf '  %s✓%s %s\n' "$G" "$O" "$1"; }
 bad()  { printf '  %s✗%s %s\n' "$R" "$O" "$1"; FAILED=1; }
 FAILED=0
 
-step "Pre-flight"
-if bash scripts/check-env.sh >/dev/null 2>&1; then ok "environment"; else bad "environment (run: npm run check-env)"; fi
+step "Typecheck — all workspaces"
+if npm run typecheck; then ok "all workspace typechecks"; else bad "typecheck"; fi
 
-step "Typecheck — 6 packages"
-if npm run typecheck >/dev/null 2>&1; then ok "agent-core · channel-slack · local-chat · web · mcp · durable"; else bad "typecheck"; fi
+step "Tests — all workspaces and offline regressions"
+if npm test; then ok "all tests passed"; else bad "tests (see command output above)"; fi
 
-step "Tests — components and safety properties"
-TEST_OUT=$(npm test 2>&1)
-PASS=$(printf '%s' "$TEST_OUT" | grep -oE '^# pass [0-9]+' | head -1 | grep -oE '[0-9]+')
-FAIL=$(printf '%s' "$TEST_OUT" | grep -oE '^# fail [0-9]+' | head -1 | grep -oE '[0-9]+')
-if [ "${FAIL:-1}" = "0" ]; then ok "${PASS:-?} passing, 0 failing"; else bad "${FAIL:-?} failing"; fi
-
-step "MCP server — real protocol round trip"
-MCP_PORT=3299
-( cd apps/mcp && MCP_PORT=$MCP_PORT node --import tsx src/server.ts >/tmp/verify-mcp.log 2>&1 & echo $! > /tmp/verify-mcp.pid )
-for _ in $(seq 1 40); do curl -sf "http://localhost:$MCP_PORT/health" >/dev/null 2>&1 && break; sleep 0.25; done
-
-call() {
-  curl -s -X POST "http://localhost:$MCP_PORT/mcp" \
-    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d "$1"
-}
-grep_ok() { printf '%s' "$1" | grep -q "$2"; }
-
-INIT=$(call '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"verify","version":"0"}}}')
-grep_ok "$INIT" '"protocolVersion"' && ok "initialize" || bad "initialize"
-
-LIST=$(call '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}')
-grep_ok "$LIST" 'incident_card' && ok "tools/list exposes incident_card" || bad "tools/list"
-grep_ok "$LIST" 'openai/outputTemplate' && ok "ChatGPT UI metadata intact" || bad "ChatGPT UI metadata"
-
-CALL=$(call '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"incident_card","arguments":{"headline":"Checkout latency above 4s","summary":"~12% of checkouts, EU"}}}')
-grep_ok "$CALL" '"structuredContent"' && ok "tools/call returns structuredContent" || bad "tools/call"
-
-READ=$(call '{"jsonrpc":"2.0","id":4,"method":"resources/read","params":{"uri":"ui://widget/incident-card.html"}}')
-grep_ok "$READ" 'window.openai' && ok "widget resource serves the openai bridge" || bad "resources/read"
-
-kill "$(cat /tmp/verify-mcp.pid)" 2>/dev/null; rm -f /tmp/verify-mcp.pid
+step "MCP server — real stdio protocol round trip"
+if node scripts/verify-mcp.mjs; then ok "MCP stdio protocol"; else bad "MCP stdio protocol"; fi
 
 step "Not proven here"
+printf '  %s·%s MCP HTTP transport — this check exercises stdio only\n' "$Y" "$O"
 printf '  %s·%s Slack round trip — needs your own Intelligence project + Channel\n' "$Y" "$O"
-printf '  %s·%s Mobile on a device — installs and typechecks, never launched\n' "$Y" "$O"
+printf '  %s·%s Mobile — separate install, typecheck, and device run not verified\n' "$Y" "$O"
 printf '  %s·%s Trigger.dev waitpoints — needs a Trigger project\n' "$Y" "$O"
 
 if [ "$FAILED" = "0" ]; then

--- a/scripts/verify.test.mjs
+++ b/scripts/verify.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { verifyMcp } from "./verify-mcp.mjs";
+
+async function runVerifier(t, testExitCode = 0) {
+  const root = await mkdtemp(join(tmpdir(), "offline-verifier-"));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  await mkdir(join(root, "scripts"));
+  await mkdir(join(root, "bin"));
+  await copyFile(new URL("./verify.sh", import.meta.url), join(root, "scripts/verify.sh"));
+  // A preflight sentinel must never be run by offline verification.
+  await writeFile(join(root, "scripts/check-env.sh"), `echo PREFLIGHT_CALLED; exit ${testExitCode ? 0 : 1}\n`);
+  await writeFile(join(root, "bin/npm"), `#!/bin/sh
+if [ "$1" = "test" ]; then
+  echo '# pass 13'
+  echo '# fail 0'
+  echo 'later workspace failed'
+  exit ${testExitCode}
+fi
+exit 0
+`, { mode: 0o755 });
+  await writeFile(join(root, "bin/node"), "#!/bin/sh\necho 'MCP protocol passed'\n", { mode: 0o755 });
+  return spawnSync("bash", [join(root, "scripts/verify.sh")], {
+    env: { PATH: `${join(root, "bin")}:${process.env.PATH}` },
+    encoding: "utf8",
+    timeout: 15000,
+  });
+}
+
+test("offline verification succeeds without .env or provider credentials", async (t) => {
+  const result = await runVerifier(t);
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.doesNotMatch(result.stdout, /PREFLIGHT_CALLED/);
+  assert.match(result.stdout, /Mobile — separate install, typecheck, and device run not verified/);
+});
+
+test("a later workspace's nonzero test status fails verification", async (t) => {
+  const result = await runVerifier(t, 7);
+  assert.equal(result.status, 1, result.stdout + result.stderr);
+  assert.match(result.stdout, /later workspace failed/);
+});
+
+// Real subprocesses: these prove ownership/cleanup, without live model calls.
+
+class TrackedTransport extends StdioClientTransport {
+  ownedPid;
+  async start() {
+    await super.start();
+    this.ownedPid = this.pid;
+  }
+}
+
+function assertChildStopped(transport) {
+  assert.equal(typeof transport.ownedPid, "number");
+  assert.throws(() => process.kill(transport.ownedPid, 0), { code: "ESRCH" });
+}
+
+test("MCP checks use the real stdio server and close their child", async () => {
+  const transport = new TrackedTransport({
+    command: process.execPath,
+    args: ["--import", "tsx", "apps/mcp/src/stdio.ts"],
+    env: {},
+    stderr: "pipe",
+  });
+  await verifyMcp({ transport });
+  assertChildStopped(transport);
+});
+
+test("MCP timeout fails explicitly and closes only its owned child", async (t) => {
+  const unrelated = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"]);
+  t.after(() => unrelated.kill());
+  const transport = new TrackedTransport({
+    command: process.execPath,
+    args: ["-e", "setInterval(() => {}, 1000)"],
+    env: {},
+    stderr: "pipe",
+  });
+  await assert.rejects(verifyMcp({ transport, timeoutMs: 100 }), /timed out/);
+  assertChildStopped(transport);
+  assert.doesNotThrow(() => process.kill(unrelated.pid, 0));
+});
+
+test("MCP startup failure rejects instead of claiming protocol success", async () => {
+  const transport = new TrackedTransport({
+    command: process.execPath,
+    args: ["-e", "process.exit(2)"],
+    env: {},
+    stderr: "pipe",
+  });
+  await assert.rejects(verifyMcp({ transport }), /closed/i);
+  assertChildStopped(transport);
+});
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  test(`MCP ${signal} handler rejects and cleans up its child`, async () => {
+    const before = process.listeners(signal);
+    const transport = new TrackedTransport({
+      command: process.execPath,
+      args: ["-e", "process.stderr.write('ready'); setInterval(() => {}, 1000)"],
+      env: {},
+      stderr: "pipe",
+    });
+    // Deliver the signal event once the owned child is alive and blocked in initialize.
+    transport.stderr.once("data", () => process.emit(signal));
+    await assert.rejects(verifyMcp({ transport }), new RegExp(signal));
+    assertChildStopped(transport);
+    assert.deepEqual(process.listeners(signal), before);
+  });
+}
+
+test("an MCP request error fails verification and still closes the child", async () => {
+  const transport = new TrackedTransport({
+    command: process.execPath,
+    args: ["-e", `
+      require('node:readline').createInterface({ input: process.stdin }).on('line', line => {
+        const request = JSON.parse(line);
+        if (request.id === undefined) return;
+        const response = request.method === 'initialize'
+          ? { result: { protocolVersion: '2025-06-18', capabilities: { tools: {} }, serverInfo: { name: 'broken', version: '1' } } }
+          : { error: { code: -32603, message: 'tools unavailable' } };
+        console.log(JSON.stringify({ jsonrpc: '2.0', id: request.id, ...response }));
+      });
+    `],
+    env: {},
+    stderr: "pipe",
+  });
+  await assert.rejects(verifyMcp({ transport }), /tools unavailable/);
+  assertChildStopped(transport);
+});


### PR DESCRIPTION
Participants need a clear path from choosing sponsor technology to demonstrating an agent that uses the context around it. This PR makes that path explicit with optional sponsor recipes, a contextual incident workspace, and working approval/research examples.

- Reorganizes onboarding around choosing a surface, adding sponsor capabilities, and showing a focused contextual demo. Adds an eight-sponsor recipe guide and an accurate surface capability matrix.
- Makes OpenAI/OpenRouter selection explicit and validates only the selected chat provider. Keeps OpenRouter model variants intact and uses its chat-completions endpoint.
- Turns the web example into a sample incident workspace whose selection, timeline, and local follow-ups are shared with the agent. Handles partial streamed cards safely and loads the root environment for web startup.
- Adds approved Exa research through Trigger.dev with origin-checked result retrieval in the original conversation. Results are retrieved when requested; this does not promise automatic push delivery. Managed action proposals record a decision without executing a production action.
- Adds runnable Auth0 machine-to-machine authorization and Mozilla incident-trace examples. The Auth0 example creates an in-memory follow-up behind a scoped JWT; the Mozilla example verifies actual incident-tool evidence and bounds model/tool steps.
- Makes offline verification independent of credentials, checks MCP over its real stdio protocol, and adds CI for the starter and both optional examples.

Validation: all six workspace typechecks passed; 109 starter-kit tests, 20 Auth0 tests, and 12 Mozilla tests passed with none skipped. The web production build, MCP stdio checks, actionlint, fresh npm installs, Python dependency checks, and 92 local documentation links passed. The final commits preserve the exact tested source tree.

Live Slack/Intelligence delivery, Trigger cloud waitpoints, sponsor-account calls, MCP HTTP transport, and mobile hardware were not exercised. External documentation URL reachability was not rechecked by the final gate. Existing dependency audit advisories and the Google Vertex dynamic-dependency build warning remain.
