### PR TITLE
Align starter guidance with the published hackathon handbook

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -2,7 +2,7 @@
 
 Record the offers and redemption instructions provided by event organizers.
 Do not assume a public plan or account signup includes hackathon credits. Check
-[the San Francisco event page](https://sf.aitinkerers.org/p/agents-everywhere-bots-channels-more-global-hackathon)
+[the official portal](https://sf.aitinkerers.org/hackathons/h_XWWQL5eKfJM)
 and the opening-session announcements; local offers may differ.
 
 | Sponsor | Build with it | Organizer offer / redemption link | Claimed |
@@ -15,6 +15,7 @@ and the opening-session announcements; local offers may differ.
 | Auth0 | [Protected action](dev-docs/sponsors.md#auth0) | | ☐ |
 | Mozilla.ai | [Agent trace](dev-docs/sponsors.md#mozillaai) | | ☐ |
 | Ambiguous AI | [Workplace follow-up](dev-docs/sponsors.md#ambiguous-ai) | | ☐ |
+| Google Cloud Run | [Deployment configuration](dev-docs/sponsors.md#google-cloud-run) | | ☐ |
 
 Use only the tools your idea needs. See [sponsor recipes](dev-docs/sponsors.md) for
 configuration and result checks; record actual usage in your submission.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Build an agent that belongs where people already work, talk, and live.
 
 </div>
 
-Built for **[Agents, Everywhere: Bots, Channels, & More](https://sf.aitinkerers.org/p/agents-everywhere-bots-channels-more-global-hackathon)**, the AI Tinkerers global hackathon on **September 12, 2026**. Start with a working example, connect the sponsor tools your idea needs, and make the surrounding context useful. You do not need every sponsor or every surface.
+Built for **[Agents, Everywhere: Bots, Channels, & More](https://sf.aitinkerers.org/p/agents-everywhere-bots-channels-more-global-hackathon)**, the AI Tinkerers global hackathon on **September 12, 2026**. Start with a working example, connect the sponsor tools your idea needs, and make the surrounding context useful. You do not need every sponsor or every surface. See the [official portal](https://sf.aitinkerers.org/hackathons/h_XWWQL5eKfJM) for deadlines and judging, and the [handbook](https://sf.aitinkerers.org/hackathons/h_XWWQL5eKfJM/handbook) for eligibility.
+
+**Build eligibility:** This kit and its incident demo are reusable starting points. Your submitted project and its core functionality must be built during the official hackathon period. A pre-existing project cannot be resubmitted or extended and entered as a new project. Explain what you inherited and what you built during the event in [your submission](SUBMISSION.md#build-eligibility).
 
 ## The demo you can build on
 
@@ -83,12 +85,13 @@ Each [sponsor recipe](dev-docs/sponsors.md) includes access, configuration, comm
 | Auth0 | Deny an unauthenticated action, authorize a service, create a local record | [Runnable M2M example](examples/auth0/README.md) |
 | Mozilla.ai | Run an incident tool and save an inspectable agent trace | [Runnable Python example](examples/mozilla/README.md) |
 | Ambiguous AI | Create a real workspace follow-up and return its link | [Workplace actions](dev-docs/sponsors.md#ambiguous-ai) |
+| Google Cloud Run | Host your configured listener beyond your laptop | [Deployment configuration](dev-docs/sponsors.md#google-cloud-run) |
 
 Auth0 and Mozilla are independent examples. Auth0 demonstrates machine authorization; the separate CIBA consent extension is still unimplemented. Live sponsor calls require your own accounts and are not proven by offline checks. Record organizer-provided offers in [CREDITS.md](CREDITS.md).
 
 ## The Context Ladder
 
-Use this **starter-kit design exercise** to sharpen your demo. It is not the event's judging rubric; the event page says that rubric will be announced.
+Use this **starter-kit design exercise** to sharpen your demo. The [published rubric](https://sf.aitinkerers.org/hackathons/h_XWWQL5eKfJM) scores Core Requirements & Functionality, Innovation & Theme Alignment, Technical Execution & Integration, and Usefulness & Agentic Experience from 1–5 each. The ladder supplements that rubric; use the [criterion-by-criterion demo checklist](SUBMISSION.md#evidence-for-the-judging-criteria) to prepare evidence.
 
 | Level | The agent… | Try this |
 |---|---|---|

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -1,8 +1,18 @@
 # Submission checklist
 
-Use the [event page](https://sf.aitinkerers.org/p/agents-everywhere-bots-channels-more-global-hackathon)
-and organizer announcements for the final deadline, upload instructions, and
-judging rubric. The Context Ladder in this kit is design guidance, not the rubric.
+Use the [official portal](https://sf.aitinkerers.org/hackathons/h_XWWQL5eKfJM) for the submission deadline and published judging criteria, and the [handbook](https://sf.aitinkerers.org/hackathons/h_XWWQL5eKfJM/handbook) for eligibility and required deliverables. The Context Ladder is supplemental kit guidance.
+
+## Build eligibility
+
+- [ ] Our submitted project is a net-new build created during the official hackathon period
+- [ ] Its core functionality was built during the event; we are not resubmitting or extending a pre-existing project and entering it as new
+- [ ] We identify inherited templates, libraries, prompts, components, and starter code separately from our event work
+
+**What we inherited**
+<!-- Include this starter kit and any reused examples. -->
+
+**What we built during the hackathon**
+<!-- Describe the new core interaction and point to its implementation. Running the supplied incident demo alone does not establish a new project. -->
 
 ## Title and description
 
@@ -17,6 +27,21 @@ judging rubric. The Context Ladder in this kit is design guidance, not the rubri
 
 **Sponsor technologies used**
 <!-- Name the tools you actually used and the visible contribution of each. -->
+
+## Evidence for the judging criteria
+
+Judges score each of the four official criteria from 1–5. This checklist helps you gather evidence; it does not guarantee a score. A working starter is a foundation for your own project.
+
+| Official criterion | Show in your project and demo |
+|---|---|
+| Core Requirements & Functionality | Run one complete workflow in the intended environment, from user request through tools to a verified result. Repeat it with live integrations; offline tests alone do not prove the deployed flow. |
+| Innovation & Theme Alignment | Show the surrounding context before the prompt and explain the original interaction it enables. Compare with the context removed: what value would a standalone chatbox lose? |
+| Technical Execution & Integration | Show how tools, data, and the environment connect. Demonstrate a relevant failure or cancellation path and explain recovery, state persistence, and integration limits. |
+| Usefulness & Agentic Experience | Identify the user and problem, show a meaningful action in the surface, and demonstrate clear feedback and appropriate user control. Explain what work the agent saves. |
+
+- [ ] We can point to visible evidence for every criterion
+- [ ] We distinguish live services, sample data, session-only state, and standalone recipes
+- [ ] Sponsor technologies contribute to the workflow; their count is not a judging criterion
 
 ## Public repository
 

--- a/dev-docs/demo-prompts.md
+++ b/dev-docs/demo-prompts.md
@@ -2,6 +2,8 @@
 
 The point is to show work informed by its surroundings and a result visible where the interaction began. Choose either the Slack workflow or the browser workflow, then add only the sponsor capabilities you need.
 
+These are reference interactions to learn from. Build your own project and its core functionality during the event, and distinguish that work from inherited starter code. See [build eligibility](../SUBMISSION.md#build-eligibility).
+
 ## Slack: context, sources, card, follow-up
 
 Prerequisites: [Slack setup](setup.md), your selected model provider, Exa for research, and an isolated Ambiguous AI demo workspace for the external-task step. The [sponsor recipes](sponsors.md) give the exact configuration.
@@ -77,3 +79,5 @@ Expected: `incident_card`, `timeline`, `create_followup`, and `select_incident` 
 5. Explain what the surrounding context made possible.
 
 A second surface is optional. State what is sample data, what changed locally, and what reached a real service. See [SUBMISSION.md](../SUBMISSION.md) for the event checklist.
+
+Before recording, use the [four-criterion evidence checklist](../SUBMISSION.md#evidence-for-the-judging-criteria). Show your original interaction, one verified outcome, appropriate user control, and a relevant failure or cancellation case. Sponsor usage should explain how the result became possible.

--- a/dev-docs/deploy.md
+++ b/dev-docs/deploy.md
@@ -52,3 +52,20 @@ Server-side only. Never log credentials, provider tokens, or raw payloads. Log
 startup status, status transitions, the Channel code, tool errors with
 idempotency ids, and event/turn/delivery ids for correlation — never message
 bodies or files.
+
+## Google Cloud Run listener configuration
+
+This is the deployment path for the [Cloud Run sponsor recipe](sponsors.md#google-cloud-run). It assumes you have prepared a container image; this repository does not supply a Dockerfile or a tested Cloud Run deployment.
+
+1. Package the repository workspaces and dependencies in a Node.js 22+ Linux image. Run `npm ci` with development dependencies included: the source entrypoint uses `tsx`. Exclude `.env`, credentials, generated traces, and local dependencies from the image/build context. Set the container working directory to `apps/channel-slack` within the packaged repository (so `tsx` uses its Channels JSX configuration), and use this entrypoint, which reads injected environment variables without requiring a local `.env` file:
+
+   ```bash
+   node --import tsx src/server.ts
+   ```
+
+2. Test that image locally with your configured environment, then publish it to your container registry. In Cloud Run, follow [Deploy container images](https://cloud.google.com/run/docs/deploying). The listener reads Cloud Run's injected `PORT` and opens it only after the Channel reports online. Use a TCP startup probe; the kit does not provide a dedicated HTTP health endpoint. Managed messages arrive over an outbound connection, so the HTTP service does not need public unauthenticated access.
+3. Configure non-secret `MODEL_PROVIDER`, `MODEL`, and `CHANNEL_CODE`. Inject the selected provider key and `INTELLIGENCE_API_KEY` through [Secret Manager](https://cloud.google.com/run/docs/configuring/secrets), granting the service identity access to the selected secrets. Add only the optional sponsor configuration your workflow uses; do not bake keys into the image.
+4. Select [instance-based billing](https://cloud.google.com/run/docs/configuring/billing-settings) so CPU is available outside HTTP requests, and set service-level [minimum](https://cloud.google.com/run/docs/configuring/min-instances) and [maximum](https://cloud.google.com/run/docs/configuring/max-instances) instances to **1** for this demo. Minimum instances incur ongoing cost. A maximum of one is not a guarantee against transient overlap during replacement or deployment; do not roll out changes while approval buttons are pending. Avoid traffic splitting between listener revisions.
+5. Stop any laptop listener using the same Intelligence project. Confirm the deployed logs report the Channel online, then mention the bot in a populated Slack thread and check its card against the thread. Exercise an approval while the same instance is running and retrieve completed research if configured. A healthy container alone is not proof of successful Slack delivery.
+
+Instances can still restart. Pending inline approval buttons are lost on restart; create a fresh request if that happens. For durable research whose approval was already recorded, retrieve its run ID in the original conversation after the listener returns. See [scaling constraints](#scaling) before adapting this for production. No cloud deployment is performed by the kit's offline checks.

--- a/dev-docs/sponsors.md
+++ b/dev-docs/sponsors.md
@@ -1,6 +1,6 @@
 # Sponsor recipes
 
-Choose a sponsor because its capability improves your demo. All eight are optional additions except the model provider needed by the chat quickstart. Auth0 and Mozilla are independent examples; installing them is not required for root startup.
+Choose a sponsor because its capability improves your demo. The nine sponsors listed in the [official portal](https://sf.aitinkerers.org/hackathons/h_XWWQL5eKfJM) offer capabilities you can choose from; the chat quickstart needs a model provider. Auth0 and Mozilla are independent examples; installing them is not required for root startup.
 
 Each recipe below gives a concrete result to verify. Live account access, billing and external writes are separate from `npm run verify`. Organizer offers belong in [CREDITS.md](../CREDITS.md).
 
@@ -91,3 +91,13 @@ examples/mozilla/.venv/bin/python examples/mozilla/trace_incident.py
 - **Result:** Open the returned URL and verify the actual record's title/content. If the connected MCP response does not provide a usable record link, complete that integration before treating the demo as successful.
 - **Customize:** [workplace.ts](../packages/agent-core/src/capabilities/workplace.ts) and [prompt.ts](../packages/agent-core/src/prompt.ts).
 - **Status:** Optional shared-agent MCP configuration implemented; live workspace tools and writes are unverified by offline checks. The approval prompt/card is not an enforced wrapper around every MCP tool. Use an isolated demo workspace and approve a concrete write. This path is different from the browser's session-only follow-ups.
+
+## Google Cloud Run
+
+- **Value:** Keep your agent available in its workplace surface after you close your laptop.
+- **Access:** A Google Cloud project with billing, Cloud Run deployment permissions, a container registry, and a configured Slack/Intelligence installation. Start with Google's [container deployment guide](https://cloud.google.com/run/docs/deploying).
+- **Configure:** Follow the [Cloud Run listener configuration](deploy.md#google-cloud-run-listener-configuration) for the container entrypoint, injected secrets, CPU allocation, instance limits, and deployment checks.
+- **Run:** Deploy your prepared listener image through Cloud Run's **Deploy container** flow using those settings. Stop the laptop listener for the same Intelligence project, then mention the bot in your incident thread.
+- **Result:** The deployed listener reports online and returns a context-informed card in Slack with the laptop listener stopped. Test an approval and a subsequent result retrieval in that same environment.
+- **Customize:** Your deployment image/configuration and [listener entrypoint](../apps/channel-slack/src/server.ts).
+- **Status:** Configuration recipe, not a supplied container image or a cloud-verified deployment. Prepare and test the image first. Cloud Run may replace instances; this does not make process-local approval handlers persistent. Hosting adds availability, but your project's contextual interaction supplies the theme alignment.

--- a/dev-docs/tools-and-context.md
+++ b/dev-docs/tools-and-context.md
@@ -67,7 +67,7 @@ lets handlers be recovered after a restart when a durable store is configured.
 
 This kit ships `incident_card` and `timeline`. Use a native artifact when it makes
 the incident easier to understand. The Context Ladder is kit design guidance,
-not an announced judging rubric.
+supplemental to the [published judging rubric](https://sf.aitinkerers.org/hackathons/h_XWWQL5eKfJM).
 
 ## Managed action proposals
 


### PR DESCRIPTION
The starter kit still described judging as unannounced, omitted the handbook's net-new build rule, and covered eight of the nine sponsors now listed in the event portal. This updates participant guidance to the published event requirements.

- Link the official portal and handbook, explain permitted starter reuse, and require teams to distinguish inherited code from core functionality built during the event.
- Map all four judging criteria to concrete demo evidence and retain the Context Ladder as supplemental guidance.
- Add Google Cloud Run to sponsor recipes and credits, with listener configuration, secret injection, single-instance constraints, and a live validation checklist.

The Cloud Run recipe requires a prepared container image; this PR does not add a Dockerfile or claim a verified cloud deployment. Application code and dependencies are unchanged.

Validation: independent documentation review passed; all six workspace typechecks passed; 78 local links, including 25 anchors, resolved; git diff --check passed. Event requirements were checked against the live portal/handbook and deployment settings against official Google Cloud documentation. No cloud deployment was performed.
