### PR TITLE
Persist approved web follow-ups in Ambiguous

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,9 @@ EXA_SEARCH_TYPE=fast
 # Use your demo workspace Connect instructions: https://www.ambiguous.ai/auth.md
 # Full sponsor setup and first calls: using-sponsor-tools.md
 # AMBIGUOUS_API_KEY=
+
+# Web approval metadata needs persistent disk (not task storage).
+# Defaults to apps/web/.data/web-approvals when run with npm run dev:web.
+# Keep the approval server on loopback unless you add your own auth and
+# trusted-origin boundary.
+# WEB_APPROVAL_DIR=/absolute/path/to/web-approvals

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ dist/
 next-env.d.ts
 assets/fonts/
 apps/mobile/.expo/
+
+# Web approval and attempt metadata (not task storage)
+.data/

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The included Slack app supplies thread history, subscriptions, search, and Chann
 
 An agent sees the page you are on and turns a request into a real workplace record you can still find after a refresh. Adapt it to customer follow-ups, a project workspace, or a personal planning app.
 
-The included web app supplies page context, frontend tools, and agent-rendered UI. Connect an Ambiguous AI workspace for persistent records, then run `npm run dev:web`. The sample app also has local follow-ups; those reset on refresh. The template shows how to verify the external record separately.
+The included web app supplies page context, frontend tools, agent-rendered UI, and a browser approval step. Connect an Ambiguous AI workspace, then run `npm run dev:web`; approved follow-ups are saved through the server and can be read back after refresh.
 
 **[Use the web template →](templates/web.md)** · [CopilotKit docs](https://docs.copilotkit.ai/) · [Ambiguous AI setup](using-sponsor-tools.md#ambiguous-ai)
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -50,7 +50,7 @@ npm run bundle:android
 npm start
 ```
 
-Press `i` for the iOS Simulator or `a` for Android. For a physical device, first make the web runtime reachable from the device, then scan the Expo code.
+Press `i` for the iOS Simulator or `a` for Android. For a physical device, first make the mobile runtime reachable from the device with a deliberate host or deployment, then scan the Expo code.
 
 ## Runtime URL
 
@@ -60,9 +60,9 @@ The default endpoint is `http://localhost:3100/api/mobile-copilotkit`, served by
 | --- | --- |
 | iOS Simulator | `http://localhost:3100/api/mobile-copilotkit` |
 | Android emulator | `http://10.0.2.2:3100/api/mobile-copilotkit` |
-| Physical device | `http://<your-laptop-LAN-IP>:3100/api/mobile-copilotkit` using the LAN URL printed by `npm run dev:web`, or after deploying the runtime |
+| Physical device | A deliberately exposed or deployed runtime URL, for example `http://<your-laptop-LAN-IP>:3100/api/mobile-copilotkit` only after starting Next.js on a LAN interface you trust |
 
-Put the override in `apps/mobile/.env`. Current main runs Next.js without a forced host binding. For a physical device, use the LAN URL printed by `npm run dev:web`, or deploy the runtime first.
+Put the override in `apps/mobile/.env`. The default `npm run dev:web` binds Next.js to loopback for the web approval demo, so a physical device will need an explicitly exposed host, a tunnel/deployment, or a separate runtime start command with the security boundary you intend.
 
 ## What to try
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,11 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "node --env-file-if-exists=../../.env ../../node_modules/next/dist/bin/next dev --turbopack -p 3100",
+    "dev": "node --env-file-if-exists=../../.env ../../node_modules/next/dist/bin/next dev --turbopack -p 3100 -H 127.0.0.1",
     "build": "next build",
-    "start": "node --env-file-if-exists=../../.env ../../node_modules/next/dist/bin/next start -p 3100",
+    "start": "node --env-file-if-exists=../../.env ../../node_modules/next/dist/bin/next start -p 3100 -H 127.0.0.1",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test src/lib/incidents.test.ts src/components/streamed-cards.test.ts"
+    "test": "node --import tsx --test src/lib/*.test.ts src/lib/server/*.test.ts src/components/streamed-cards.test.ts",
+    "check:workplace": "node --env-file-if-exists=../../.env --import tsx scripts/check-workplace.ts"
   },
   "dependencies": {
     "@copilotkit/react-core": "1.70.1",
@@ -17,10 +18,12 @@
     "next": "^15.5.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "zod": "^4.1.0"
+    "zod": "^4.1.0",
+    "@modelcontextprotocol/sdk": "^1.30.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "@types/react-dom": "^19.0.0",
+    "tsx": "^4.20.5"
   }
 }

--- a/apps/web/scripts/check-workplace.ts
+++ b/apps/web/scripts/check-workplace.ts
@@ -1,0 +1,78 @@
+/** Read-only schema discovery; initialization and tools/list require no account. */
+import assert from "node:assert/strict";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { configuredWorkplace } from "../src/lib/server/workplace";
+
+async function main() {
+  const client = new Client({
+    name: "agents-everywhere-schema-check",
+    version: "0.1.0",
+  });
+  const validator = new AjvJsonSchemaValidator();
+  const inputs = {
+    auth_whoami: {},
+    create_task: {
+      title: "Schema check only — never sent",
+      description: "No task is created by this script.",
+    },
+    get_task: { id: "11111111-1111-4111-8111-111111111111" },
+    list_tasks: {
+      q: "agents-everywhere:INC-1042",
+      limit: 100,
+      cursor: "schema-check",
+    },
+  };
+  try {
+    await client.connect(
+      new StreamableHTTPClientTransport(
+        new URL("https://app.ambiguous.ai/mcp"),
+      ),
+      { timeout: 15_000 },
+    );
+    const tools: Tool[] = [];
+    const cursors = new Set<string>();
+    let cursor: string | undefined;
+    do {
+      const page = await client.listTools(cursor ? { cursor } : {}, {
+        timeout: 15_000,
+      });
+      tools.push(...page.tools);
+      cursor = page.nextCursor;
+      if (cursor) {
+        assert.ok(!cursors.has(cursor), "Repeated catalog cursor");
+        cursors.add(cursor);
+      }
+    } while (cursor);
+    for (const [name, input] of Object.entries(inputs)) {
+      const tool = tools.find((t) => t.name === name);
+      assert.ok(tool, `Missing MCP tool: ${name}`);
+      assert.ok(
+        validator.getValidator(tool.inputSchema)(input).valid,
+        `${name} input schema changed`,
+      );
+      console.log(`Verified live MCP input schema: ${name}`);
+    }
+    console.log(
+      `Discovered ${tools.length} tools. No workspace tool calls or writes were made.`,
+    );
+  } finally {
+    await client.close();
+  }
+  if (process.argv.includes("--identity")) {
+    const connection = configuredWorkplace();
+    try {
+      console.log("Connected identity:", await connection.workplace.identity());
+    } finally {
+      await connection.close();
+    }
+  }
+}
+main().catch(() => {
+  console.error(
+    "Workplace check failed. Inspect the live catalog, network access, and (with --identity) AMBIGUOUS_API_KEY and workspace permissions.",
+  );
+  process.exitCode = 1;
+});

--- a/apps/web/src/app/api/copilotkit/[[...path]]/route.ts
+++ b/apps/web/src/app/api/copilotkit/[[...path]]/route.ts
@@ -17,11 +17,15 @@
  *    out a fresh agent per resolution.
  */
 import { randomUUID } from "node:crypto";
-import { CopilotRuntime, createCopilotHonoHandler } from "@copilotkit/runtime/v2";
+import {
+  CopilotRuntime,
+  createCopilotHonoHandler,
+} from "@copilotkit/runtime/v2";
 import { makeAgent } from "agent-core";
 
+// Web writes use /api/followups after a browser approval. Never expose raw MCP writes here.
 const runtime = new CopilotRuntime({
-  agents: () => ({ default: makeAgent(randomUUID()) }),
+  agents: () => ({ default: makeAgent(randomUUID(), { workplace: false }) }),
 });
 
 const app = createCopilotHonoHandler({

--- a/apps/web/src/app/api/followups/route.ts
+++ b/apps/web/src/app/api/followups/route.ts
@@ -1,0 +1,12 @@
+import { resolve } from "node:path";
+import { createFollowupHandler } from "@/lib/server/followup-http";
+import { configuredWorkplace } from "@/lib/server/workplace";
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+const handler = createFollowupHandler({
+  connect: () =>
+    process.env.AMBIGUOUS_API_KEY?.trim() ? configuredWorkplace() : undefined,
+  directory: resolve(process.env.WEB_APPROVAL_DIR || ".data/web-approvals"),
+});
+export const GET = handler;
+export const POST = handler;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -88,7 +88,7 @@ p {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 24px;
-  align-items: start;
+  align-items: flex-start;
 }
 .ck-panel {
   background: var(--surface);
@@ -452,4 +452,82 @@ p {
   padding: 0.9rem 1rem;
   overflow-x: auto;
   white-space: pre-wrap;
+}
+
+/* Persistent workplace follow-ups */
+.ck-followups-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.ck-task-form--stacked {
+  display: grid;
+  gap: 8px;
+  margin-top: 16px;
+}
+.ck-task-form--stacked input,
+.ck-task-form--stacked textarea {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--text);
+}
+.ck-task-form--stacked textarea {
+  resize: vertical;
+}
+.ck-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.ck-record-id {
+  display: block;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  margin: 5px 0;
+}
+.ck-muted {
+  color: var(--muted);
+  font-size: 12px;
+}
+.ck-task-list .ck-muted {
+  display: block;
+}
+.ck-preserve-lines {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.ck-setup-note,
+.ck-approval {
+  background: #f7f7f9;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  margin: 16px 0;
+  overflow-wrap: anywhere;
+}
+.ck-setup-note p,
+.ck-approval p {
+  font-size: 13px;
+  line-height: 1.6;
+}
+.ck-approval h3 {
+  font-size: 14px;
+  margin-bottom: 8px;
+}
+.ck-approval-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.ck-error {
+  color: #a12730;
+  background: #fff1f2;
+  padding: 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  overflow-wrap: anywhere;
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,37 +1,25 @@
 "use client";
 
-import { useCallback, useState, type FormEvent } from "react";
+import { useCallback, useState } from "react";
 import {
   CopilotChat,
   useConfigureSuggestions,
 } from "@copilotkit/react-core/v2";
 import { GenerativeUI } from "@/components/generative-ui";
 import { AppControl } from "@/components/app-control";
-import {
-  createFollowup,
-  findIncident,
-  incidents,
-  workspaceContext,
-  type Followup,
-} from "@/lib/incidents";
+import { findIncident, incidents, workspaceContext } from "@/lib/incidents";
+import { useWorkplace } from "@/lib/use-workplace";
+import { WorkplaceFollowups } from "@/components/workplace-followups";
 
 export default function Home() {
   const [selectedId, setSelectedId] = useState<string>(incidents[0].id);
-  const [followups, setFollowups] = useState<Followup[]>([]);
-  const [title, setTitle] = useState("");
-  const [notice, setNotice] = useState("");
-  const { selectedIncident: incident, followups: visibleTasks } =
-    workspaceContext(selectedId, followups);
+  const workplace = useWorkplace(selectedId);
+  const { selectedIncident: incident } = workspaceContext(
+    selectedId,
+    workplace.status?.status === "connected" ? workplace.status.tasks : [],
+  );
   const selectIncident = useCallback((id: string) => {
     setSelectedId(findIncident(id).id);
-    setTitle("");
-    setNotice("");
-  }, []);
-  const addFollowup = useCallback((incidentId: string, nextTitle: string) => {
-    const task = createFollowup(incidentId, nextTitle, crypto.randomUUID());
-    setFollowups((current) => [...current, task]);
-    setNotice(`Added a follow-up to ${task.incidentId}.`);
-    return task;
   }, []);
 
   useConfigureSuggestions(
@@ -43,9 +31,9 @@ export default function Home() {
             "Summarize the selected incident using the page context. What needs attention?",
         },
         {
-          title: "Add a follow-up",
+          title: "Propose a follow-up",
           message:
-            "Add one useful local follow-up for the selected incident based on its current status.",
+            "Prepare one useful Ambiguous follow-up for the selected incident. Show me the proposal before it is saved.",
         },
       ],
       available: "before-first-message",
@@ -53,26 +41,13 @@ export default function Home() {
     [],
   );
 
-  function submitFollowup(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    try {
-      addFollowup(selectedId, title);
-      setTitle("");
-    } catch (error) {
-      setNotice(
-        error instanceof Error ? error.message : "Unable to add follow-up.",
-      );
-    }
-  }
-
   return (
     <>
       <GenerativeUI />
       <AppControl
         selectedId={selectedId}
-        followups={followups}
         selectIncident={selectIncident}
-        addFollowup={addFollowup}
+        workplace={workplace}
       />
       <main className="ck-workspace">
         <header className="ck-workspace-header">
@@ -80,7 +55,7 @@ export default function Home() {
             <p className="ck-eyebrow">Agents, everywhere · Web example</p>
             <h1>Incident assistant</h1>
             <p className="ck-intro">
-              Pick an incident. Ask your assistant. Add a follow-up.
+              Pick an incident. Ask your assistant. Review a follow-up.
             </p>
           </div>
           <span className="ck-tag">Sample data</span>
@@ -140,45 +115,7 @@ export default function Home() {
               </details>
             </div>
 
-            <section className="ck-followups" aria-labelledby="followup-title">
-              <h2 id="followup-title">Follow-ups</h2>
-              {visibleTasks.length ? (
-                <ul className="ck-task-list">
-                  {visibleTasks.map((task) => (
-                    <li key={task.id}>
-                      <span aria-hidden="true">○</span>
-                      {task.title}
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="ck-empty">
-                  No follow-ups yet. Ask the assistant or add one.
-                </p>
-              )}
-              <form onSubmit={submitFollowup} className="ck-task-form">
-                <label className="ck-sr-only" htmlFor="task-title">
-                  New follow-up for {incident.id}
-                </label>
-                <input
-                  id="task-title"
-                  value={title}
-                  onChange={(event) => setTitle(event.target.value)}
-                  maxLength={200}
-                  placeholder="Write a follow-up…"
-                  required
-                />
-                <button className="ck-btn ck-btn--primary" type="submit">
-                  Add
-                </button>
-              </form>
-              <p className="ck-local-note">
-                Saved for this session. Cleared on refresh.
-              </p>
-              <p role="status" className="ck-notice">
-                {notice}
-              </p>
-            </section>
+            <WorkplaceFollowups incidentId={selectedId} workplace={workplace} />
           </section>
 
           <section
@@ -187,7 +124,7 @@ export default function Home() {
           >
             <header className="ck-assistant-header">
               <h2 id="assistant-title">Ask assistant</h2>
-              <p>It can read this incident and add follow-ups.</p>
+              <p>It can read this incident and prepare follow-ups.</p>
             </header>
             <CopilotChat
               className="ck-chat"

--- a/apps/web/src/components/app-control.tsx
+++ b/apps/web/src/components/app-control.tsx
@@ -2,23 +2,47 @@
 
 import { useFrontendTool, useAgentContext } from "@copilotkit/react-core/v2";
 import { z } from "zod";
-import { findIncident, workspaceContext, type Followup } from "@/lib/incidents";
+import { findIncident, workspaceContext } from "@/lib/incidents";
+import type { WorkplaceControls } from "@/lib/use-workplace";
+
+async function toolResult<T>(action: () => Promise<T>) {
+  try {
+    return await action();
+  } catch (error) {
+    return {
+      status: "error",
+      message:
+        error instanceof Error
+          ? error.message
+          : "Workplace operation failed. Check the page for setup details.",
+    };
+  }
+}
 
 export function AppControl({
   selectedId,
-  followups,
   selectIncident,
-  addFollowup,
+  workplace,
 }: {
   selectedId: string;
-  followups: Followup[];
   selectIncident: (id: string) => void;
-  addFollowup: (incidentId: string, title: string) => Followup;
+  workplace: WorkplaceControls;
 }) {
+  const { status, propose, retrieve } = workplace;
+
   useAgentContext({
     description:
-      "The incident workspace currently visible to the user, including sample timeline and local follow-ups. Use this context without asking the user to paste it. Never describe sample observations as live production data.",
-    value: workspaceContext(selectedId, followups),
+      "The incident workspace currently visible to the user, including sample timeline and Ambiguous follow-ups. CRITICAL: propose_followup only prepares a proposal. Only the user's approval button saves it; prose/chat approval never executes a write. Use retrieve_followup or refresh_followups for real reads. Never claim a task was saved without a provider record. Never invent record links.",
+    value: {
+      ...workspaceContext(
+        selectedId,
+        status?.status === "connected" ? status.tasks : [],
+      ),
+      workplace: status?.status ?? "unavailable",
+      workplaceError: workplace.error,
+      proposal: workplace.proposal ?? null,
+      lastResult: workplace.notice,
+    },
   });
 
   useFrontendTool(
@@ -38,19 +62,44 @@ export function AppControl({
 
   useFrontendTool(
     {
-      name: "create_followup",
+      name: "propose_followup",
       description:
-        "Add a follow-up task for a known incident in this browser page session only. Does not create a workplace task, send a notification, or change production. Use the selected incident unless the user specifies another.",
+        "Prepare an Ambiguous task from the selected incident context. Show the exact title and details for the user's approval button. Does not save anything. CRITICAL: wait for the user to click Approve & save to Ambiguous in the page.",
       parameters: z.object({
         incidentId: z.string(),
         title: z.string().trim().min(1).max(200),
+        details: z.string().trim().min(1).max(4000),
       }),
-      handler: async ({ incidentId, title }) => {
-        const task = addFollowup(incidentId, title);
-        return `Added local follow-up ${task.id} to ${task.incidentId}: ${task.title}. It is visible under that incident and will be cleared on refresh; no external system was updated.`;
-      },
+      handler: async (draft) =>
+        toolResult(async () => ({
+          status: "pending_approval",
+          proposal: await propose(draft),
+        })),
     },
-    [addFollowup],
+    [propose],
   );
+
+  useFrontendTool(
+    {
+      name: "retrieve_followup",
+      description:
+        "Retrieve an existing Ambiguous task by its actual ID. Read-only; never creates a duplicate.",
+      parameters: z.object({ id: z.uuid() }),
+      handler: async ({ id }) => toolResult(() => retrieve(id)),
+    },
+    [retrieve],
+  );
+
+  useFrontendTool(
+    {
+      name: "refresh_followups",
+      description:
+        "Read saved follow-ups for the currently selected incident from Ambiguous. Use after approval or browser refresh to verify persistence.",
+      parameters: z.object({}),
+      handler: async () => toolResult(() => workplace.refresh()),
+    },
+    [workplace.refresh],
+  );
+
   return null;
 }

--- a/apps/web/src/components/workplace-followups.tsx
+++ b/apps/web/src/components/workplace-followups.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import type { WorkplaceControls } from "@/lib/use-workplace";
+
+export function WorkplaceFollowups({
+  incidentId,
+  workplace,
+}: {
+  incidentId: string;
+  workplace: WorkplaceControls;
+}) {
+  const [title, setTitle] = useState("");
+  const [details, setDetails] = useState("");
+  const [error, setError] = useState("");
+  const [preparing, setPreparing] = useState(false);
+  const { status, proposal, busy, notice } = workplace;
+  const tasks = status?.status === "connected" ? status.tasks : [];
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPreparing(true);
+    setError("");
+    try {
+      await workplace.propose({ incidentId, title, details });
+      setTitle("");
+      setDetails("");
+    } catch (error) {
+      setError(
+        error instanceof Error ? error.message : "Unable to prepare proposal.",
+      );
+    } finally {
+      setPreparing(false);
+    }
+  }
+
+  async function refresh() {
+    setError("");
+    try {
+      await workplace.refresh();
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : "Unable to refresh follow-ups from Ambiguous.",
+      );
+    }
+  }
+
+  return (
+    <section className="ck-followups" aria-labelledby="followup-title">
+      <header className="ck-followups-header">
+        <div>
+          <h2 id="followup-title">Follow-ups</h2>
+          <p className="ck-local-note">
+            Proposals are saved only after page approval. Refresh reads the
+            provider again.
+          </p>
+        </div>
+        <span className="ck-tag">Ambiguous</span>
+      </header>
+
+      {status?.status === "unconfigured" ? (
+        <div className="ck-setup-note">
+          <strong>Connect a workspace to save tasks</strong>
+          <p>{status.message}</p>
+          <p>
+            You can still inspect sample incidents. No browser-only task will
+            be created as a stand-in.
+          </p>
+        </div>
+      ) : status?.status === "connected" ? (
+        <p className="ck-local-note">
+          Retrieved from Ambiguous as {status.identityName}. Workspace{" "}
+          <code>{status.workspaceId}</code>.
+        </p>
+      ) : (
+        <p className="ck-local-note">
+          {workplace.error
+            ? "Workplace connection unavailable."
+            : "Connecting to Ambiguous…"}
+        </p>
+      )}
+
+      {tasks.length ? (
+        <ul className="ck-task-list">
+          {tasks.map((task) => (
+            <li key={task.id}>
+              <span aria-hidden="true">○</span>
+              <div>
+                <strong>{task.title}</strong>
+                <code className="ck-record-id">{task.id}</code>
+                {task.url ? (
+                  <a href={task.url} target="_blank" rel="noreferrer">
+                    Open Ambiguous record
+                  </a>
+                ) : (
+                  <span className="ck-muted">
+                    Ambiguous returned no record link. Use this ID in the
+                    workspace.
+                  </span>
+                )}
+                <details>
+                  <summary>Saved details</summary>
+                  <p className="ck-preserve-lines">{task.description}</p>
+                </details>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : status?.status === "connected" ? (
+        <p className="ck-empty">No saved follow-ups for {incidentId}.</p>
+      ) : null}
+
+      <button
+        type="button"
+        className="ck-btn"
+        disabled={busy}
+        onClick={refresh}
+      >
+        Refresh from Ambiguous
+      </button>
+
+      <form onSubmit={submit} className="ck-task-form ck-task-form--stacked">
+        <label className="ck-sr-only" htmlFor="task-title">
+          New follow-up for {incidentId}
+        </label>
+        <input
+          id="task-title"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          maxLength={200}
+          placeholder="Write a follow-up title…"
+          required
+        />
+        <label className="ck-sr-only" htmlFor="task-details">
+          Task details
+        </label>
+        <textarea
+          id="task-details"
+          value={details}
+          onChange={(event) => setDetails(event.target.value)}
+          maxLength={4000}
+          placeholder="What needs checking, and why?"
+          required
+          rows={3}
+        />
+        <button
+          className="ck-btn ck-btn--primary"
+          disabled={status?.status !== "connected" || preparing || busy}
+          type="submit"
+        >
+          {preparing ? "Preparing…" : "Review"}
+        </button>
+      </form>
+
+      {proposal && (
+        <section className="ck-approval" aria-label="Approve Ambiguous task">
+          <h3>Approve this task in Ambiguous</h3>
+          <p>
+            Save as {proposal.identityName} in workspace{" "}
+            <code>{proposal.workspaceId}</code>. Expires{" "}
+            {new Date(proposal.expiresAt).toLocaleTimeString()}.
+          </p>
+          <strong>{proposal.title}</strong>
+          <p className="ck-preserve-lines">{proposal.description}</p>
+          <p>This is a real workplace write. Review the exact fields above.</p>
+          <div className="ck-approval-actions">
+            <button
+              type="button"
+              className="ck-btn ck-btn--primary"
+              disabled={busy}
+              onClick={workplace.approve}
+            >
+              {busy ? "Working…" : "Approve & save to Ambiguous"}
+            </button>
+            <button
+              type="button"
+              className="ck-btn"
+              disabled={busy}
+              onClick={workplace.deny}
+            >
+              Decline
+            </button>
+          </div>
+        </section>
+      )}
+
+      {(error || workplace.error) && (
+        <p role="alert" className="ck-error">
+          {error || workplace.error}
+        </p>
+      )}
+      <p role="status" className="ck-notice">
+        {notice}
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/lib/followup-client.test.ts
+++ b/apps/web/src/lib/followup-client.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createFollowupClient } from "./followup-client";
+test("parallel reads and proposals wait for a single completed session handshake", async () => {
+  const urls: string[] = [];
+  let sessionReady = false;
+  let release: () => void = () => {
+    throw new Error("not initialized");
+  };
+  const hold = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const request = createFollowupClient(async (url) => {
+    urls.push(url);
+    if (url.includes("session=1")) {
+      await hold;
+      sessionReady = true;
+    } else assert.equal(sessionReady, true);
+    return Response.json({ status: "ready" });
+  });
+  const reads = [
+    request("?incidentId=INC-1042"),
+    request("?incidentId=INC-1043"),
+    request("", { operation: "propose" }),
+  ];
+  assert.deepEqual(urls, ["/api/followups?session=1"]);
+  release();
+  await Promise.all(reads);
+  assert.equal(urls.filter((url) => url.includes("session=1")).length, 1);
+  assert.equal(urls.length, 4);
+});
+test("a failed handshake can be retried and never sends a proposal", async () => {
+  let calls = 0;
+  const request = createFollowupClient(async () => {
+    calls++;
+    return new Response(null, { status: 503 });
+  });
+  await assert.rejects(request("", { operation: "propose" }), /session/);
+  await assert.rejects(request("", { operation: "propose" }), /session/);
+  assert.equal(calls, 2);
+});

--- a/apps/web/src/lib/followup-client.ts
+++ b/apps/web/src/lib/followup-client.ts
@@ -1,0 +1,42 @@
+type Fetcher = (url: string, init?: RequestInit) => Promise<Response>;
+
+/** All page reads and tools share one cookie handshake, including React's development effect replay. */
+export function createFollowupClient(fetcher: Fetcher) {
+  let session: Promise<void> | undefined;
+  const initialize = () =>
+    (session ??= (async () => {
+      const response = await fetcher("/api/followups?session=1", {
+        cache: "no-store",
+      });
+      if (!response.ok)
+        throw new Error(
+          "Unable to start the approval session. Reload the page.",
+        );
+      await response.json();
+    })().catch((error) => {
+      session = undefined;
+      throw error;
+    }));
+  return async function request<T>(path: string, body?: unknown): Promise<T> {
+    await initialize();
+    const response = await fetcher(
+      `/api/followups${path}`,
+      body
+        ? {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          }
+        : { cache: "no-store" },
+    );
+    const result = await response.json();
+    if (!response.ok)
+      throw new Error(
+        result.error || `Request failed: HTTP ${response.status}`,
+      );
+    return result;
+  };
+}
+export const requestFollowups = createFollowupClient((url, init) =>
+  fetch(url, init),
+);

--- a/apps/web/src/lib/followup-types.ts
+++ b/apps/web/src/lib/followup-types.ts
@@ -1,0 +1,23 @@
+export type WorkplaceTask = {
+  id: string;
+  title: string;
+  description: string;
+  url: string | null;
+};
+export type Proposal = {
+  id: string;
+  incidentId: string;
+  title: string;
+  description: string;
+  workspaceId: string;
+  identityName: string;
+  expiresAt: number;
+};
+export type WorkplaceStatus =
+  | { status: "unconfigured"; message: string }
+  | {
+      status: "connected";
+      workspaceId: string;
+      identityName: string;
+      tasks: WorkplaceTask[];
+    };

--- a/apps/web/src/lib/incidents.test.ts
+++ b/apps/web/src/lib/incidents.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { createFollowup, findIncident, workspaceContext } from "./incidents";
+import { findIncident, workspaceContext } from "./incidents";
+import type { WorkplaceTask } from "./followup-types";
 
 test("selection changes the shared incident and timeline together", () => {
   const checkout = workspaceContext("INC-1042", []);
@@ -11,27 +12,18 @@ test("selection changes the shared incident and timeline together", () => {
   assert.equal(notifications.availableIncidents.length, 2);
 });
 
-test("follow-ups are trimmed and scoped to their incident when switching", () => {
-  const tasks = [
-    createFollowup("INC-1042", "  Check pool metrics  ", "task-1"),
-    createFollowup("INC-1043", "Watch queue", "task-2"),
+test("workspace context labels sample incidents and provider follow-ups", () => {
+  const tasks: WorkplaceTask[] = [
+    {
+      id: "11111111-1111-4111-8111-111111111111",
+      title: "Check pool metrics",
+      description: "Provider task details\nagents-everywhere:INC-1042",
+      url: null,
+    },
   ];
-  assert.equal(tasks[0].title, "Check pool metrics");
-  assert.deepEqual(workspaceContext("INC-1042", tasks).followups, [tasks[0]]);
-  assert.deepEqual(workspaceContext("INC-1043", tasks).followups, [tasks[1]]);
-  assert.equal(tasks.length, 2);
-});
-
-test("unknown incidents and empty or oversized follow-ups are rejected", () => {
+  const context = workspaceContext("INC-1042", tasks);
   assert.throws(() => findIncident("unknown"), /Unknown incident/);
-  assert.throws(
-    () => createFollowup("unknown", "Task", "1"),
-    /Unknown incident/,
-  );
-  assert.throws(() => createFollowup("INC-1042", " \n ", "1"), /title/);
-  assert.throws(() => createFollowup("INC-1042", "x".repeat(201), "1"), /200/);
-  assert.match(
-    workspaceContext("INC-1042", []).dataSource,
-    /No external task system/,
-  );
+  assert.match(context.dataSource, /Fictional sample/);
+  assert.match(context.dataSource, /Ambiguous/);
+  assert.deepEqual(context.followups, tasks);
 });

--- a/apps/web/src/lib/incidents.ts
+++ b/apps/web/src/lib/incidents.ts
@@ -1,4 +1,6 @@
-/** Sample workspace data. All follow-ups live only in the current React session. */
+/** Sample incident context. Follow-ups are retrieved separately from Ambiguous. */
+import type { WorkplaceTask } from "./followup-types";
+
 export const incidents = [
   {
     id: "INC-1042",
@@ -66,11 +68,6 @@ export const incidents = [
 ] as const;
 
 export type Incident = (typeof incidents)[number];
-export type Followup = {
-  id: string;
-  incidentId: Incident["id"];
-  title: string;
-};
 
 export function findIncident(id: string): Incident {
   const incident = incidents.find((item) => item.id === id);
@@ -81,24 +78,13 @@ export function findIncident(id: string): Incident {
   return incident;
 }
 
-export function createFollowup(
-  incidentId: string,
-  title: string,
-  id: string,
-): Followup {
-  const incident = findIncident(incidentId);
-  const trimmed = title.trim();
-  if (!trimmed)
-    throw new Error("Enter a follow-up title before adding a task.");
-  if (trimmed.length > 200)
-    throw new Error("Keep the follow-up title to 200 characters or fewer.");
-  return { id, incidentId: incident.id, title: trimmed };
-}
-
-export function workspaceContext(selectedId: string, followups: Followup[]) {
+export function workspaceContext(
+  selectedId: string,
+  followups: WorkplaceTask[],
+) {
   return {
     dataSource:
-      "Fictional sample incidents. Follow-ups exist only in this browser page session; refreshing clears them. No external task system is updated.",
+      "Fictional sample incidents. Follow-ups shown here were retrieved from Ambiguous for the selected incident. A proposal is not a saved task.",
     availableIncidents: incidents.map(({ id, title, status }) => ({
       id,
       title,
@@ -108,6 +94,6 @@ export function workspaceContext(selectedId: string, followups: Followup[]) {
       ...findIncident(selectedId),
       timeline: [...findIncident(selectedId).timeline],
     },
-    followups: followups.filter((task) => task.incidentId === selectedId),
+    followups,
   };
 }

--- a/apps/web/src/lib/server/followup-error.ts
+++ b/apps/web/src/lib/server/followup-error.ts
@@ -1,0 +1,2 @@
+/** Controlled messages that are safe to show in the browser; never wrap raw provider text. */
+export class FollowupError extends Error {}

--- a/apps/web/src/lib/server/followup-http.test.ts
+++ b/apps/web/src/lib/server/followup-http.test.ts
@@ -1,0 +1,300 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createFollowupHandler } from "./followup-http";
+import type { Workplace, WorkplaceTask } from "./workplace";
+const origin = "http://localhost:3100";
+const cookie = `web-followup-session=${"a".repeat(64)}`;
+const request = (body: unknown, headers: Record<string, string> = {}) =>
+  new Request(`${origin}/api/followups`, {
+    method: "POST",
+    headers: { origin, cookie, "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+const proposal = {
+  operation: "propose",
+  incidentId: "INC-1042",
+  title: "Compare metrics",
+  details: "Use the selected incident context.",
+};
+
+test("unconfigured GET establishes a protected session, while writes fail explicitly", async () => {
+  const handler = createFollowupHandler({
+    connect: () => undefined,
+    directory: "/unused",
+  });
+  const response = await handler(new Request(`${origin}/api/followups`));
+  assert.equal((await response.json()).status, "unconfigured");
+  assert.match(
+    response.headers.get("set-cookie")!,
+    /HttpOnly; SameSite=Strict/,
+  );
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal((await handler(request(proposal))).status, 503);
+});
+
+test("cross-origin posts, absent sessions, and form bodies cannot reach a provider", async () => {
+  let connects = 0;
+  const handler = createFollowupHandler({
+    connect: () => {
+      connects++;
+      return undefined;
+    },
+    directory: "/unused",
+  });
+  const invalidHeaders: Record<string, string>[] = [
+    { origin: "https://evil.example" },
+    { cookie: "" },
+    { "content-type": "application/x-www-form-urlencoded" },
+    { origin: "" },
+  ];
+  for (const headers of invalidHeaders) {
+    assert.equal((await handler(request(proposal, headers))).status, 403);
+  }
+  assert.equal(connects, 0);
+});
+
+test("HTTP proposal/approval/read flow rejects edited fields and never writes on reads", async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), "web-http-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const records: WorkplaceTask[] = [];
+  let creates = 0;
+  const workplace: Workplace = {
+    async identity() {
+      return { id: "u1", workspaceId: "w1", name: "Test identity" };
+    },
+    async list(marker) {
+      return records.filter((r) => r.description.includes(marker));
+    },
+    async get(id) {
+      const record = records.find((r) => r.id === id);
+      if (!record) throw new Error("missing");
+      return record;
+    },
+    async create(title, description, beforeWrite) {
+      await beforeWrite();
+      creates++;
+      const record = {
+        id: "11111111-1111-4111-8111-111111111111",
+        title,
+        description,
+        url: null,
+      };
+      records.push(record);
+      return record;
+    },
+  };
+  const handler = createFollowupHandler({
+    connect: () => ({ workplace, async close() {} }),
+    directory,
+  });
+  const response = await handler(request(proposal));
+  const { proposal: prepared } = await response.json();
+  assert.equal(creates, 0);
+  assert.equal(
+    (
+      await handler(
+        request({
+          operation: "approve",
+          proposalId: prepared.id,
+          title: "edited by client",
+        }),
+      )
+    ).status,
+    400,
+  );
+  assert.equal(creates, 0);
+  const saved = await handler(
+    request({ operation: "approve", proposalId: prepared.id }),
+  );
+  assert.equal(saved.status, 200);
+  const { task } = await saved.json();
+  assert.equal(task.description, prepared.description);
+  const refreshed = await handler(
+    new Request(`${origin}/api/followups?incidentId=INC-1042`, {
+      headers: { cookie },
+    }),
+  );
+  assert.equal((await refreshed.json()).tasks[0].id, task.id);
+  const retrieved = await handler(
+    new Request(`${origin}/api/followups?taskId=${task.id}`, {
+      headers: { cookie },
+    }),
+  );
+  assert.equal((await retrieved.json()).task.id, task.id);
+  assert.equal(creates, 1);
+});
+
+test("provider credential errors remain errors and never leak arbitrary provider text", async () => {
+  const handler = createFollowupHandler({
+    connect: () => {
+      throw new Error("Bearer secret-api-key");
+    },
+    directory: "/unused",
+  });
+  const response = await handler(new Request(`${origin}/api/followups`));
+  assert.equal(response.status, 502);
+  const body = await response.text();
+  assert.match(body, /credentials/);
+  assert.doesNotMatch(body, /secret-api-key/);
+});
+
+test("session bootstrap returns before any provider connection and does not reset an established cookie", async () => {
+  let connects = 0;
+  const handler = createFollowupHandler({
+    connect: () => {
+      connects++;
+      throw new Error("should not connect");
+    },
+    directory: "/unused",
+  });
+  const response = await handler(
+    new Request(`${origin}/api/followups?session=1`),
+  );
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("set-cookie")!, /web-followup-session=/);
+  const established = await handler(
+    new Request(`${origin}/api/followups?session=1`, { headers: { cookie } }),
+  );
+  assert.equal(established.headers.get("set-cookie"), null);
+  assert.equal(connects, 0);
+});
+
+test("a loopback Host preserved by Next accepts only its matching browser Origin", async () => {
+  const handler = createFollowupHandler({
+    connect: () => undefined,
+    directory: "/unused",
+  });
+  const accepted = await handler(
+    request(proposal, {
+      host: "127.0.0.1:3100",
+      origin: "http://127.0.0.1:3100",
+    }),
+  );
+  assert.equal(accepted.status, 503); // Origin passed; Ambiguous is unconfigured.
+  for (const origin of [
+    "https://evil.example",
+    "http://127.0.0.1:3101",
+    "https://127.0.0.1:3100",
+  ]) {
+    assert.equal(
+      (await handler(request(proposal, { host: "127.0.0.1:3100", origin })))
+        .status,
+      403,
+    );
+  }
+});
+
+test("an attacker-controlled matching Host and Origin cannot bootstrap or call the provider", async () => {
+  let connects = 0;
+  const handler = createFollowupHandler({
+    connect: () => {
+      connects++;
+      return undefined;
+    },
+    directory: "/unused",
+  });
+  const headers = {
+    host: "attacker.example:3100",
+    origin: "http://attacker.example:3100",
+  };
+  for (const incoming of [
+    request(proposal, headers),
+    new Request(`${origin}/api/followups?session=1`, { headers }),
+    new Request(`${origin}/api/followups`, { headers }),
+  ]) {
+    assert.equal((await handler(incoming)).status, 403);
+  }
+  assert.equal(connects, 0);
+});
+
+
+test("cleanup failures do not mask successful provider responses", async (t) => {
+  const originalWarn = console.warn;
+  const warnings: unknown[][] = [];
+  console.warn = (...args: unknown[]) => warnings.push(args);
+  t.after(() => {
+    console.warn = originalWarn;
+  });
+  const workplace: Workplace = {
+    async identity() {
+      return { id: "u1", workspaceId: "w1", name: "Test identity" };
+    },
+    async list() {
+      return [
+        {
+          id: "22222222-2222-4222-8222-222222222222",
+          title: "Compare metrics",
+          description: "agents-everywhere:INC-1042",
+          url: null,
+        },
+      ];
+    },
+    async get() {
+      throw new Error("unused");
+    },
+    async create() {
+      throw new Error("unused");
+    },
+  };
+  const handler = createFollowupHandler({
+    connect: () => ({
+      workplace,
+      async close() {
+        throw new Error("Bearer secret-after-success");
+      },
+    }),
+    directory: "/unused",
+  });
+  const response = await handler(
+    new Request(`${origin}/api/followups?incidentId=INC-1042`, {
+      headers: { cookie },
+    }),
+  );
+  assert.equal(response.status, 200);
+  assert.equal((await response.json()).tasks[0].title, "Compare metrics");
+  assert.equal(warnings.length, 1);
+  assert.doesNotMatch(String(warnings[0].join(" ")), /secret-after-success/);
+});
+
+test("cleanup failures do not mask controlled provider errors", async (t) => {
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  t.after(() => {
+    console.warn = originalWarn;
+  });
+  const workplace: Workplace = {
+    async identity() {
+      throw new Error("provider denied with hidden-token");
+    },
+    async list() {
+      throw new Error("unused");
+    },
+    async get() {
+      throw new Error("unused");
+    },
+    async create() {
+      throw new Error("unused");
+    },
+  };
+  const handler = createFollowupHandler({
+    connect: () => ({
+      workplace,
+      async close() {
+        throw new Error("close also failed with hidden-token");
+      },
+    }),
+    directory: "/unused",
+  });
+  const response = await handler(
+    new Request(`${origin}/api/followups?incidentId=INC-1042`, {
+      headers: { cookie },
+    }),
+  );
+  assert.equal(response.status, 502);
+  const body = await response.text();
+  assert.match(body, /Unable to reach Ambiguous/);
+  assert.doesNotMatch(body, /hidden-token/);
+});

--- a/apps/web/src/lib/server/followup-http.ts
+++ b/apps/web/src/lib/server/followup-http.ts
@@ -1,0 +1,170 @@
+import { FollowupError } from "./followup-error";
+import { randomBytes } from "node:crypto";
+import { z } from "zod";
+import { FollowupService } from "./followups";
+import type { Workplace } from "./workplace";
+const cookieName = "web-followup-session";
+const command = z.discriminatedUnion("operation", [
+  z
+    .object({
+      operation: z.literal("propose"),
+      incidentId: z.string(),
+      title: z.string(),
+      details: z.string(),
+    })
+    .strict(),
+  z.object({ operation: z.literal("approve"), proposalId: z.uuid() }).strict(),
+  z.object({ operation: z.literal("deny"), proposalId: z.uuid() }).strict(),
+]);
+const setup =
+  "Set AMBIGUOUS_API_KEY in root .env and restart the web app. Select sample incidents now; saving and retrieval require a real Ambiguous workspace.";
+
+async function closeConnection(connection: { close(): Promise<void> }) {
+  try {
+    await connection.close();
+  } catch {
+    // Keep cleanup non-masking: the request response is already determined, and
+    // provider close errors can contain transport or credential details.
+    console.warn("Ambiguous workplace cleanup failed after response handling.");
+  }
+}
+
+export function createFollowupHandler(options: {
+  connect(): { workplace: Workplace; close(): Promise<void> } | undefined;
+  directory: string;
+}) {
+  return async (request: Request) => {
+    const url = new URL(request.url);
+    // Next may normalize request.url to localhost. Compare Origin with the actual HTTP Host.
+    const expectedOrigin = new URL(url);
+    expectedOrigin.host = request.headers.get("host") || url.host;
+    const cookie = request.headers
+      .get("cookie")
+      ?.split(";")
+      .map((s) => s.trim())
+      .find((s) => s.startsWith(`${cookieName}=`))
+      ?.slice(cookieName.length + 1);
+    const hasSession = !!cookie && /^[a-f0-9]{64}$/.test(cookie);
+    const session = hasSession ? cookie : randomBytes(32).toString("hex");
+    const reply = (value: unknown, status = 200) =>
+      Response.json(value, {
+        status,
+        headers: {
+          "Cache-Control": "no-store",
+          ...(!hasSession
+            ? {
+                "Set-Cookie": `${cookieName}=${session}; HttpOnly; SameSite=Strict; Path=/api/followups; Max-Age=86400${url.protocol === "https:" ? "; Secure" : ""}`,
+              }
+            : {}),
+        },
+      });
+    // A matching arbitrary Host/Origin can be DNS rebinding against a local credential.
+    // Deployment must add authenticated users and a deliberate trusted-origin allowlist.
+    if (
+      !["localhost", "127.0.0.1", "[::1]"].includes(expectedOrigin.hostname)
+    ) {
+      return Response.json(
+        { error: "This demo accepts loopback hosts only." },
+        { status: 403 },
+      );
+    }
+    if (request.method !== "GET" && request.method !== "POST")
+      return reply({ error: "Method not allowed." }, 405);
+    if (
+      request.method === "POST" &&
+      (request.headers.get("origin") !== expectedOrigin.origin ||
+        !request.headers.get("content-type")?.startsWith("application/json"))
+    ) {
+      return reply(
+        { error: "Use the approval controls from this app's own page." },
+        403,
+      );
+    }
+    if (request.method === "POST" && !hasSession)
+      return reply(
+        {
+          error:
+            "Reload the page to start a browser session before proposing or approving.",
+        },
+        403,
+      );
+    if (request.method === "GET" && url.searchParams.get("session") === "1")
+      return reply({ status: "ready" });
+    let connection: ReturnType<typeof options.connect> = undefined;
+    const withCleanup = async (response: Response) => {
+      if (connection) await closeConnection(connection);
+      return response;
+    };
+    try {
+      connection = options.connect();
+      if (!connection)
+        return await withCleanup(
+          reply(
+            request.method === "GET"
+              ? { status: "unconfigured", message: setup }
+              : { error: setup },
+            request.method === "GET" ? 200 : 503,
+          ),
+        );
+      const service = new FollowupService(
+        connection.workplace,
+        options.directory,
+      );
+      if (request.method === "GET") {
+        const id = url.searchParams.get("taskId");
+        if (id) return await withCleanup(reply({ task: await service.get(id) }));
+        const identity = await connection.workplace.identity();
+        return await withCleanup(
+          reply({
+            status: "connected",
+            workspaceId: identity.workspaceId,
+            identityName: identity.name,
+            tasks: await service.list(
+              url.searchParams.get("incidentId") ?? "INC-1042",
+            ),
+          }),
+        );
+      }
+      const text = await request.text();
+      if (text.length > 12_000)
+        return await withCleanup(
+          reply({ error: "The proposal is too large." }, 413),
+        );
+      const input = command.parse(JSON.parse(text));
+      switch (input.operation) {
+        case "propose": {
+          const { operation: _operation, ...draft } = input;
+          return await withCleanup(
+            reply({ proposal: await service.propose(session, draft) }),
+          );
+        }
+        case "deny":
+          await service.deny(session, input.proposalId);
+          return await withCleanup(reply({ status: "declined" }));
+        case "approve":
+          return await withCleanup(
+            reply({
+              task: await service.approve(session, input.proposalId),
+            }),
+          );
+      }
+    } catch (error) {
+      if (error instanceof z.ZodError || error instanceof SyntaxError)
+        return await withCleanup(
+          reply(
+            {
+              error:
+                "Invalid request or provider data. Check the incident, title, details, and record ID.",
+            },
+            400,
+          ),
+        );
+      // Only our controlled domain messages are safe to expose. Transport errors can contain credentials.
+      const message =
+        error instanceof FollowupError
+          ? error.message
+          : "Unable to reach Ambiguous or the approval store. Check the server configuration, credentials, permissions, and persistent disk, then refresh.";
+      return await withCleanup(reply({ error: message }, 502));
+    }
+  };
+}

--- a/apps/web/src/lib/server/followups.test.ts
+++ b/apps/web/src/lib/server/followups.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test, { type TestContext } from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { FollowupService } from "./followups";
+import type { Workplace, WorkplaceTask } from "./workplace";
+
+const session = "a".repeat(64);
+const input = {
+  incidentId: "INC-1042",
+  title: "Check pool metrics",
+  details: "Compare before and after deploy.",
+};
+class FakeWorkplace implements Workplace {
+  workspaceId = "workspace-a";
+  tasks: WorkplaceTask[] = [];
+  creates = 0;
+  reads = 0;
+  failure: "before" | "after" | undefined;
+  async identity() {
+    return { id: "user-a", workspaceId: this.workspaceId, name: "Demo agent" };
+  }
+  async list(marker: string) {
+    this.reads++;
+    return this.tasks.filter((t) => t.description.includes(marker));
+  }
+  async get(id: string) {
+    this.reads++;
+    const task = this.tasks.find((t) => t.id === id);
+    if (!task) throw new Error("not found");
+    return task;
+  }
+  async create(
+    title: string,
+    description: string,
+    beforeWrite: () => Promise<void>,
+  ) {
+    await beforeWrite();
+    this.creates++;
+    if (this.failure === "before") throw new Error("provider unavailable");
+    const task = {
+      id: "11111111-1111-4111-8111-111111111111",
+      title,
+      description,
+      url: null,
+    };
+    this.tasks.push(task);
+    if (this.failure === "after") throw new Error("lost response");
+    return task;
+  }
+}
+async function fixture(t: TestContext) {
+  const directory = await mkdtemp(join(tmpdir(), "web-followups-"));
+  t.after(() => rm(directory, { recursive: true, force: true }));
+  const provider = new FakeWorkplace();
+  let now = Date.now();
+  const service = new FollowupService(provider, directory, () => now);
+  return {
+    service,
+    provider,
+    directory,
+    expire: () => {
+      now += 11 * 60_000;
+    },
+  };
+}
+
+test("a proposal performs no write; approval writes exactly the displayed fields and reads back", async (t) => {
+  const { service, provider } = await fixture(t);
+  const proposal = await service.propose(session, input);
+  assert.equal(provider.creates, 0);
+  const task = await service.approve(session, proposal.id);
+  assert.equal(task.title, proposal.title);
+  assert.equal(task.description, proposal.description);
+  assert.equal(provider.creates, 1);
+  assert.ok(provider.reads > 0);
+});
+
+test("missing, foreign-session, denied, and expired proposals cannot write", async (t) => {
+  const { service, provider, expire } = await fixture(t);
+  await assert.rejects(service.approve(session, "missing"));
+  const proposal = await service.propose(session, input);
+  await assert.rejects(service.approve("b".repeat(64), proposal.id), /session/);
+  await service.deny(session, proposal.id);
+  await assert.rejects(service.approve(session, proposal.id), /declined/);
+  const next = await service.propose(session, input);
+  expire();
+  await assert.rejects(service.approve(session, next.id), /expired/);
+  assert.equal(provider.creates, 0);
+});
+
+test("workspace changes invalidate the exact consent", async (t) => {
+  const { service, provider } = await fixture(t);
+  const proposal = await service.propose(session, input);
+  provider.workspaceId = "workspace-b";
+  await assert.rejects(service.approve(session, proposal.id), /workspace/);
+  assert.equal(provider.creates, 0);
+});
+
+test("concurrent approval and restart cannot duplicate a saved task; refresh reads the provider", async (t) => {
+  const { service, provider, directory } = await fixture(t);
+  const p = await service.propose(session, input);
+  const results = await Promise.allSettled([
+    service.approve(session, p.id),
+    service.approve(session, p.id),
+  ]);
+  assert.ok(results.some((r) => r.status === "fulfilled"));
+  assert.equal(provider.creates, 1);
+  const restarted = new FollowupService(provider, directory);
+  await restarted.approve(session, p.id);
+  const before = provider.reads;
+  assert.equal((await restarted.list("INC-1042"))[0].id, provider.tasks[0].id);
+  assert.ok(provider.reads > before);
+  const another = await restarted.propose(session, input);
+  await restarted.approve(session, another.id);
+  assert.equal(provider.creates, 1);
+});
+
+test("an uncertain write is never retried, including after restart and a new proposal", async (t) => {
+  const { service, provider, directory } = await fixture(t);
+  const p = await service.propose(session, input);
+  provider.failure = "before";
+  await assert.rejects(service.approve(session, p.id), /uncertain/);
+  provider.failure = undefined;
+  const restarted = new FollowupService(provider, directory);
+  await assert.rejects(restarted.approve(session, p.id), /uncertain/);
+  const another = await restarted.propose(session, input);
+  await assert.rejects(restarted.approve(session, another.id), /uncertain/);
+  assert.equal(provider.creates, 1);
+});
+
+test("a lost create reply is reconciled from Ambiguous without a second create", async (t) => {
+  const { service, provider, directory } = await fixture(t);
+  const p = await service.propose(session, input);
+  provider.failure = "after";
+  await assert.rejects(service.approve(session, p.id), /uncertain/);
+  const restarted = new FollowupService(provider, directory);
+  const task = await restarted.approve(session, p.id);
+  assert.equal(task.id, provider.tasks[0].id);
+  assert.equal(provider.creates, 1);
+});
+
+test("invalid proposal inputs fail before provider writes", async (t) => {
+  const { service, provider } = await fixture(t);
+  await assert.rejects(
+    service.propose(session, { ...input, incidentId: "unknown" }),
+  );
+  await assert.rejects(service.propose(session, { ...input, title: " " }));
+  await assert.rejects(
+    service.propose(session, { ...input, details: "x".repeat(4001) }),
+  );
+  assert.equal(provider.creates, 0);
+});
+
+test("schema discovery failure before the write guard remains retryable", async (t) => {
+  const { service, provider } = await fixture(t);
+  const original = provider.create.bind(provider);
+  provider.create = async () => {
+    throw new Error("schema unavailable");
+  };
+  const p = await service.propose(session, input);
+  await assert.rejects(service.approve(session, p.id), /schema/);
+  provider.create = original;
+  await service.approve(session, p.id);
+  assert.equal(provider.creates, 1);
+});
+
+test("read-back fields must match the exact approved payload", async (t) => {
+  const { service, provider } = await fixture(t);
+  const original = provider.get.bind(provider);
+  provider.get = async (id) => ({
+    ...(await original(id)),
+    title: "Unexpected changed title",
+  });
+  const p = await service.propose(session, input);
+  await assert.rejects(
+    service.approve(session, p.id),
+    /differs from the approved fields/,
+  );
+  assert.equal(provider.creates, 1);
+});

--- a/apps/web/src/lib/server/followups.ts
+++ b/apps/web/src/lib/server/followups.ts
@@ -1,0 +1,213 @@
+import { FollowupError } from "./followup-error";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, writeFile, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { z } from "zod";
+import { findIncident } from "../incidents";
+import type { Proposal, WorkplaceTask } from "../followup-types";
+import type { Workplace } from "./workplace";
+
+const draftSchema = z
+  .object({
+    incidentId: z.string(),
+    title: z.string().trim().min(1).max(200),
+    details: z.string().trim().min(1).max(4000),
+  })
+  .strict();
+const storedSchema = z.object({
+  id: z.uuid(),
+  incidentId: z.string(),
+  title: z.string(),
+  description: z.string(),
+  workspaceId: z.string(),
+  identityName: z.string(),
+  identityId: z.string(),
+  expiresAt: z.number(),
+  sessionHash: z.string(),
+  actionKey: z.string(),
+});
+const hash = (value: string) =>
+  createHash("sha256").update(value).digest("hex");
+const marker = (incidentId: string) =>
+  `agents-everywhere:${findIncident(incidentId).id}`;
+function fileExists(error: unknown) {
+  return error instanceof Error && "code" in error && error.code === "EEXIST";
+}
+const uncertain = () =>
+  new FollowupError(
+    "The write outcome is uncertain or still in progress. Refresh to reconcile from Ambiguous. This exact action will not be created again; inspect the workspace before starting a different task.",
+  );
+
+/** Files are approval/attempt metadata, never a source of saved task records. Keep this directory on persistent disk. */
+export class FollowupService {
+  constructor(
+    private workplace: Workplace,
+    private directory: string,
+    private now = Date.now,
+  ) {}
+  async list(incidentId: string) {
+    const tag = marker(incidentId);
+    return (await this.workplace.list(tag)).filter((t) =>
+      t.description.split("\n").includes(tag),
+    );
+  }
+  async get(id: string) {
+    return this.workplace.get(id);
+  }
+  async propose(session: string, input: unknown): Promise<Proposal> {
+    const draft = draftSchema.parse(input);
+    const incident = findIncident(draft.incidentId);
+    const identity = await this.workplace.identity();
+    const actionKey = hash(
+      JSON.stringify([
+        identity.workspaceId,
+        incident.id,
+        draft.title,
+        draft.details,
+      ]),
+    );
+    const proposal = {
+      id: randomUUID(),
+      incidentId: incident.id,
+      title: draft.title,
+      description: `${draft.details}\n\nSample incident: ${incident.id} — ${incident.title}\n${marker(incident.id)}\nfollowup:${actionKey}`,
+      workspaceId: identity.workspaceId,
+      identityName: identity.name,
+      identityId: identity.id,
+      expiresAt: this.now() + 10 * 60_000,
+      sessionHash: hash(session),
+      actionKey,
+    };
+    await mkdir(this.directory, { recursive: true, mode: 0o700 });
+    await writeFile(
+      join(this.directory, `${proposal.id}.json`),
+      JSON.stringify(proposal),
+      { flag: "wx", mode: 0o600 },
+    );
+    const {
+      sessionHash: _session,
+      actionKey: _action,
+      identityId: _identity,
+      ...publicProposal
+    } = proposal;
+    return publicProposal;
+  }
+  private async proposal(session: string, id: string) {
+    z.uuid().parse(id);
+    const proposal = storedSchema.parse(
+      JSON.parse(await readFile(join(this.directory, `${id}.json`), "utf8")),
+    );
+    if (proposal.sessionHash !== hash(session))
+      throw new FollowupError(
+        "This proposal belongs to another browser session.",
+      );
+    if (proposal.expiresAt <= this.now())
+      throw new FollowupError(
+        "This proposal expired. Prepare and review a new proposal.",
+      );
+    return proposal;
+  }
+  private async decide(id: string, decision: "approved" | "declined") {
+    const path = join(this.directory, `${id}.decision`);
+    try {
+      await writeFile(path, decision, { flag: "wx", mode: 0o600 });
+    } catch (error) {
+      if (!fileExists(error)) throw error;
+    }
+    const saved = await readFile(path, "utf8");
+    if (saved !== decision)
+      throw new FollowupError(`This proposal was already ${saved}.`);
+  }
+  async deny(session: string, id: string) {
+    await this.proposal(session, id);
+    await this.decide(id, "declined");
+  }
+  async approve(session: string, id: string): Promise<WorkplaceTask> {
+    const proposal = await this.proposal(session, id);
+    const identity = await this.workplace.identity();
+    if (
+      identity.workspaceId !== proposal.workspaceId ||
+      identity.id !== proposal.identityId
+    ) {
+      throw new FollowupError(
+        "The connected workspace or identity changed. Prepare a new proposal before approving.",
+      );
+    }
+    // The decision is bound to immutable server-held fields and this browser session.
+    await this.decide(id, "approved");
+    const reconcile = async () => {
+      const found = (
+        await this.workplace.list(`followup:${proposal.actionKey}`)
+      ).filter(
+        (t) =>
+          t.title === proposal.title && t.description === proposal.description,
+      );
+      if (found.length > 1)
+        throw new FollowupError(
+          "Ambiguous contains multiple matching records; inspect the workspace before continuing.",
+        );
+      return found[0];
+    };
+    const readBack = async (id: string) => {
+      const record = await this.workplace.get(id);
+      if (
+        record.id !== id ||
+        record.title !== proposal.title ||
+        record.description !== proposal.description
+      ) {
+        throw new FollowupError(
+          `Ambiguous task ${id} differs from the approved fields. Inspect the workspace; do not create it again.`,
+        );
+      }
+      return record;
+    };
+    const existing = await reconcile();
+    if (existing) return readBack(existing.id);
+    let sent = false;
+    let conflict = false;
+    let created: WorkplaceTask;
+    try {
+      created = await this.workplace.create(
+        proposal.title,
+        proposal.description,
+        async () => {
+          // Runs after live schema discovery, immediately before callTool. Failed discovery consumes no attempt.
+          if (proposal.expiresAt <= this.now())
+            throw new FollowupError(
+              "This proposal expired before the write. Nothing was sent.",
+            );
+          const attempt = join(this.directory, `${proposal.actionKey}.attempt`);
+          try {
+            await writeFile(attempt, id, { flag: "wx", mode: 0o600 });
+          } catch (error) {
+            if (!fileExists(error)) throw error;
+            conflict = true;
+            throw uncertain();
+          }
+          if (proposal.expiresAt <= this.now()) {
+            await unlink(attempt); // This request owns the claim and has not sent a write.
+            throw new FollowupError(
+              "This proposal expired before the write. Nothing was sent.",
+            );
+          }
+          sent = true;
+        },
+      );
+    } catch (error) {
+      if (conflict) {
+        const recovered = await reconcile();
+        if (recovered) return readBack(recovered.id);
+      }
+      if (sent || conflict) throw uncertain();
+      throw error; // A guaranteed pre-send failure remains retryable.
+    }
+    try {
+      return await readBack(created.id);
+    } catch (error) {
+      if (error instanceof FollowupError) throw error;
+      throw new FollowupError(
+        `Ambiguous created task ${created.id}, but read-back failed. Refresh to retrieve it; do not create it again.`,
+      );
+    }
+  }
+}

--- a/apps/web/src/lib/server/workplace.test.ts
+++ b/apps/web/src/lib/server/workplace.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  CallToolResult,
+  ListToolsResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  AmbiguousWorkplace,
+  configuredWorkplace,
+  type McpConnection,
+} from "./workplace";
+const id = "11111111-1111-4111-8111-111111111111";
+const task = { id, title: "Follow up", description: "Marker" };
+const catalog: ListToolsResult = {
+  tools: [
+    {
+      name: "create_task",
+      inputSchema: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          description: { type: "string" },
+        },
+        required: ["title"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "get_task",
+      inputSchema: {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "list_tasks",
+      inputSchema: {
+        type: "object",
+        properties: {
+          q: { type: "string" },
+          limit: { type: "integer" },
+          cursor: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+    },
+    {
+      name: "auth_whoami",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+  ],
+};
+class Connection implements McpConnection {
+  catalog = catalog;
+  result: CallToolResult = {
+    content: [{ type: "text", text: JSON.stringify({ task }) }],
+  };
+  calls: { name: string; arguments: Record<string, unknown> }[] = [];
+  async listTools() {
+    return this.catalog;
+  }
+  async callTool(input: { name: string; arguments: Record<string, unknown> }) {
+    this.calls.push(input);
+    return this.result;
+  }
+}
+test("missing credentials fail clearly; no local task fallback", () => {
+  assert.throws(() => configuredWorkplace(" "), /AMBIGUOUS_API_KEY/);
+});
+test("real MCP text and structured results return provider IDs and never synthesize links", async () => {
+  const c = new Connection();
+  const api = new AmbiguousWorkplace(c);
+  assert.deepEqual(await api.create("Follow up", "Marker", async () => {}), {
+    ...task,
+    url: null,
+  });
+  c.result = {
+    content: [],
+    structuredContent: {
+      task: { ...task, url: "https://app.ambiguous.ai/returned-record-link" },
+    },
+  };
+  assert.equal(
+    (await api.get(id)).url,
+    "https://app.ambiguous.ai/returned-record-link",
+  );
+});
+test("schema drift prevents writes before callTool", async () => {
+  const c = new Connection();
+  c.catalog = { tools: [] };
+  await assert.rejects(
+    new AmbiguousWorkplace(c).create("Follow up", "Marker", async () => {}),
+    /schema/,
+  );
+  assert.equal(c.calls.length, 0);
+  c.catalog = {
+    tools: [
+      {
+        ...catalog.tools[0],
+        inputSchema: {
+          ...catalog.tools[0].inputSchema,
+          required: ["new_required_argument"],
+        },
+      },
+    ],
+  };
+  await assert.rejects(
+    new AmbiguousWorkplace(c).create("Follow up", "Marker", async () => {}),
+    /schema/,
+  );
+  assert.equal(c.calls.length, 0);
+});
+test("MCP errors, malformed results, mismatched IDs and unsafe links are visible failures", async () => {
+  for (const result of [
+    {
+      content: [
+        { type: "text" as const, text: "credential details must not leak" },
+      ],
+      isError: true,
+    },
+    { content: [{ type: "text" as const, text: "not json" }] },
+    { content: [], structuredContent: { task: { title: "no ID" } } },
+    {
+      content: [],
+      structuredContent: {
+        task: { ...task, id: "22222222-2222-4222-8222-222222222222" },
+      },
+    },
+    {
+      content: [],
+      structuredContent: { task: { ...task, url: "javascript:alert(1)" } },
+    },
+  ]) {
+    const c = new Connection();
+    c.result = result;
+    await assert.rejects(
+      new AmbiguousWorkplace(c).get(id),
+      (e) => e instanceof Error && !e.message.includes("credential details"),
+    );
+  }
+});
+test("task listing uses provider pagination and fails on incomplete pagination", async () => {
+  const c = new Connection();
+  c.result = {
+    content: [],
+    structuredContent: { data: [task], has_more: false },
+  };
+  assert.equal((await new AmbiguousWorkplace(c).list("Marker")).length, 1);
+  c.result = {
+    content: [],
+    structuredContent: { data: [task], has_more: true },
+  };
+  await assert.rejects(new AmbiguousWorkplace(c).list("Marker"), /pagination/);
+});
+
+test("the approval guard runs after schema discovery immediately before the MCP write", async () => {
+  const c = new Connection();
+  let discovered = false;
+  c.listTools = async () => {
+    discovered = true;
+    return catalog;
+  };
+  await assert.rejects(
+    new AmbiguousWorkplace(c).create("Follow up", "Marker", async () => {
+      assert.equal(discovered, true);
+      throw new Error("approval expired");
+    }),
+    /approval expired/,
+  );
+  assert.equal(c.calls.length, 0);
+});

--- a/apps/web/src/lib/server/workplace.ts
+++ b/apps/web/src/lib/server/workplace.ts
@@ -1,0 +1,229 @@
+import { FollowupError } from "./followup-error";
+/** Server-only, narrow adapter. Names/schemas discovered from live tools/list on 2026-09-11. */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
+import {
+  CallToolResultSchema,
+  type CallToolResult,
+  type ListToolsResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import type { WorkplaceTask } from "../followup-types";
+export type { WorkplaceTask } from "../followup-types";
+
+export interface Workplace {
+  identity(): Promise<{ id: string; workspaceId: string; name: string }>;
+  list(marker: string): Promise<WorkplaceTask[]>;
+  get(id: string): Promise<WorkplaceTask>;
+  create(
+    title: string,
+    description: string,
+    beforeWrite: () => Promise<void>,
+  ): Promise<WorkplaceTask>;
+}
+export interface McpConnection {
+  listTools(params?: { cursor?: string }): Promise<ListToolsResult>;
+  callTool(input: {
+    name: string;
+    arguments: Record<string, unknown>;
+  }): Promise<CallToolResult>;
+}
+const taskSchema = z.object({
+  id: z.uuid(),
+  title: z.string().min(1),
+  description: z.string().nullable().optional(),
+  url: z.url().nullable().optional(),
+});
+const identitySchema = z.object({
+  id: z.string().min(1),
+  workspace_id: z.string().min(1),
+  display_name: z.string().min(1),
+});
+const validators = new AjvJsonSchemaValidator();
+
+function payload(result: CallToolResult): unknown {
+  // Do not echo arbitrary provider error bodies (which can contain sensitive data).
+  if (result.isError)
+    throw new FollowupError(
+      "Ambiguous rejected the operation. Check workspace access and tasks.read/tasks.write permissions.",
+    );
+  if (result.structuredContent) return result.structuredContent;
+  const text = result.content
+    .filter((c) => c.type === "text")
+    .map((c) => c.text)
+    .join("\n");
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new FollowupError(
+      "Ambiguous returned an unreadable result; no record is confirmed.",
+    );
+  }
+}
+function task(value: unknown): WorkplaceTask {
+  const parsed = taskSchema.safeParse(value);
+  if (!parsed.success)
+    throw new FollowupError("Ambiguous returned an invalid task record.");
+  const { id, title, description, url } = parsed.data;
+  if (url) {
+    const link = new URL(url);
+    if (
+      link.protocol !== "https:" ||
+      link.username ||
+      link.password ||
+      link.hostname !== "app.ambiguous.ai"
+    ) {
+      throw new FollowupError("Ambiguous returned an unsafe record link.");
+    }
+  }
+  // The published Task schema does not promise a URL. Never manufacture one.
+  return { id, title, description: description ?? "", url: url ?? null };
+}
+
+export class AmbiguousWorkplace implements Workplace {
+  constructor(private connection: McpConnection) {}
+  private async call(
+    name: string,
+    args: Record<string, unknown>,
+    beforeCall?: () => Promise<void>,
+  ) {
+    let cursor: string | undefined;
+    const seen = new Set<string>();
+    do {
+      const page = await this.connection.listTools(cursor ? { cursor } : {});
+      const tool = page.tools.find((t) => t.name === name);
+      if (tool) {
+        const valid = validators.getValidator(tool.inputSchema)(args);
+        if (!valid.valid)
+          throw new FollowupError(
+            `Ambiguous ${name} schema changed; review the discovered input schema before writing.`,
+          );
+        await beforeCall?.();
+        return payload(
+          await this.connection.callTool({ name, arguments: args }),
+        );
+      }
+      cursor = page.nextCursor;
+      if (cursor && seen.has(cursor))
+        throw new FollowupError(
+          "Ambiguous tool schema pagination repeated a cursor.",
+        );
+      if (cursor) seen.add(cursor);
+    } while (cursor);
+    throw new FollowupError(
+      `Ambiguous ${name} schema is unavailable. Recheck the connected workspace's MCP catalog.`,
+    );
+  }
+  async identity() {
+    const result = identitySchema.safeParse(await this.call("auth_whoami", {}));
+    if (!result.success)
+      throw new FollowupError(
+        "Ambiguous identity has no usable workspace. Complete workspace setup first.",
+      );
+    return {
+      id: result.data.id,
+      workspaceId: result.data.workspace_id,
+      name: result.data.display_name,
+    };
+  }
+  async create(
+    title: string,
+    description: string,
+    beforeWrite: () => Promise<void>,
+  ) {
+    const result = z
+      .object({ task: z.unknown() })
+      .parse(
+        await this.call("create_task", { title, description }, beforeWrite),
+      );
+    return task(result.task);
+  }
+  async get(id: string) {
+    z.uuid().parse(id);
+    const result = z
+      .object({ task: z.unknown() })
+      .parse(await this.call("get_task", { id }));
+    const record = task(result.task);
+    if (record.id !== id)
+      throw new FollowupError(
+        "Ambiguous returned a different task ID than requested.",
+      );
+    return record;
+  }
+  async list(marker: string) {
+    const records: WorkplaceTask[] = [];
+    const seen = new Set<string>();
+    let cursor: string | undefined;
+    do {
+      const value = await this.call("list_tasks", {
+        q: marker,
+        limit: 100,
+        ...(cursor ? { cursor } : {}),
+      });
+      const result = z
+        .object({
+          data: z.array(z.unknown()),
+          has_more: z.boolean(),
+          next_cursor: z.string().optional(),
+        })
+        .parse(value);
+      records.push(...result.data.map(task));
+      if (!result.has_more) return records;
+      cursor = result.next_cursor;
+      if (!cursor || seen.has(cursor))
+        throw new FollowupError(
+          "Ambiguous task pagination is incomplete; refresh before attempting a write.",
+        );
+      seen.add(cursor);
+      if (seen.size >= 100)
+        throw new FollowupError(
+          "Ambiguous task pagination exceeded this demo's limit.",
+        );
+    } while (cursor);
+    return records;
+  }
+}
+
+export function configuredWorkplace(apiKey = process.env.AMBIGUOUS_API_KEY): {
+  workplace: Workplace;
+  close(): Promise<void>;
+} {
+  if (!apiKey?.trim())
+    throw new FollowupError(
+      "Set AMBIGUOUS_API_KEY in root .env to save and retrieve real workplace tasks.",
+    );
+  const client = new Client({
+    name: "agents-everywhere-web",
+    version: "0.1.0",
+  });
+  let connected: Promise<void> | undefined;
+  const connect = () =>
+    (connected ??= client.connect(
+      new StreamableHTTPClientTransport(
+        new URL("https://app.ambiguous.ai/mcp"),
+        {
+          requestInit: {
+            headers: { Authorization: `Bearer ${apiKey.trim()}` },
+          },
+        },
+      ),
+      { timeout: 15_000 },
+    ));
+  const connection: McpConnection = {
+    async listTools(params) {
+      await connect();
+      return client.listTools(params, { timeout: 15_000 });
+    },
+    async callTool(input) {
+      await connect();
+      return CallToolResultSchema.parse(
+        await client.callTool(input, CallToolResultSchema, { timeout: 20_000 }),
+      );
+    },
+  };
+  return {
+    workplace: new AmbiguousWorkplace(connection),
+    close: () => client.close(),
+  };
+}

--- a/apps/web/src/lib/use-workplace.ts
+++ b/apps/web/src/lib/use-workplace.ts
@@ -1,0 +1,145 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  Proposal,
+  WorkplaceStatus,
+  WorkplaceTask,
+} from "./followup-types";
+
+import { requestFollowups as api } from "./followup-client";
+
+export function useWorkplace(incidentId: string) {
+  const [snapshot, setSnapshot] = useState<{
+    incidentId: string;
+    status: WorkplaceStatus;
+  }>();
+  const [proposal, setProposal] = useState<Proposal>();
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [busy, setBusy] = useState(false);
+  const sequence = useRef(0);
+  const selectedIncident = useRef(incidentId);
+  selectedIncident.current = incidentId;
+  const refresh = useCallback(async () => {
+    const incidentId = selectedIncident.current;
+    const request = ++sequence.current;
+    setError("");
+    try {
+      const status = await api<WorkplaceStatus>(
+        `?incidentId=${encodeURIComponent(incidentId)}`,
+      );
+      if (
+        request === sequence.current &&
+        incidentId === selectedIncident.current
+      )
+        setSnapshot({ incidentId, status });
+      return status;
+    } catch (error) {
+      if (
+        request === sequence.current &&
+        incidentId === selectedIncident.current
+      ) {
+        setSnapshot(undefined);
+        setError(
+          error instanceof Error
+            ? error.message
+            : "Unable to retrieve workplace tasks.",
+        );
+      }
+      throw error;
+    }
+  }, []);
+  useEffect(() => {
+    // The refresh function exposes errors in page state; the effect has no caller to reject to.
+    refresh().catch(() => {});
+    return () => {
+      sequence.current++;
+    };
+  }, [incidentId, refresh]);
+  const propose = useCallback(
+    async (draft: { incidentId: string; title: string; details: string }) => {
+      try {
+        const { proposal } = await api<{ proposal: Proposal }>("", {
+          operation: "propose",
+          ...draft,
+        });
+        setProposal(proposal);
+        setNotice("Review the exact task below. It has not been saved.");
+        setError("");
+        return proposal;
+      } catch (error) {
+        setError(
+          error instanceof Error
+            ? error.message
+            : "Unable to prepare a workplace task.",
+        );
+        throw error;
+      }
+    },
+    [],
+  );
+  const retrieve = useCallback(async (id: string) => {
+    const result = await api<{ task: WorkplaceTask }>(
+      `?taskId=${encodeURIComponent(id)}`,
+    );
+    setNotice(`Retrieved ${result.task.id} from Ambiguous.`);
+    return result.task;
+  }, []);
+  const approve = async () => {
+    if (!proposal || busy) return;
+    setBusy(true);
+    setError("");
+    try {
+      const { task } = await api<{ task: WorkplaceTask }>("", {
+        operation: "approve",
+        proposalId: proposal.id,
+      });
+      setProposal((current) =>
+        current?.id === proposal.id ? undefined : current,
+      );
+      setNotice(`Saved and read back from Ambiguous: ${task.id}.`);
+      await refresh();
+    } catch (error) {
+      setError(
+        error instanceof Error
+          ? error.message
+          : "Unable to confirm the write. Refresh before retrying.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+  const deny = async () => {
+    if (!proposal || busy) return;
+    setBusy(true);
+    setError("");
+    try {
+      await api("", { operation: "deny", proposalId: proposal.id });
+      setProposal((current) =>
+        current?.id === proposal.id ? undefined : current,
+      );
+      setNotice("Proposal declined. No task was created.");
+    } catch (error) {
+      setError(
+        error instanceof Error ? error.message : "Unable to decline proposal.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+  const status =
+    snapshot?.incidentId === incidentId ? snapshot.status : undefined;
+  return {
+    status,
+    proposal,
+    error,
+    notice,
+    busy,
+    refresh,
+    propose,
+    retrieve,
+    approve,
+    deny,
+  };
+}
+export type WorkplaceControls = ReturnType<typeof useWorkplace>;

--- a/dev-docs/demo-prompts.md
+++ b/dev-docs/demo-prompts.md
@@ -42,7 +42,7 @@ Expected: a **real task record**, with a returned URL you can open from the thre
 
 The prompt and `propose_action` guide approval behavior but do not enforce approval around every external MCP call. Use a demo workspace. For an enforced authorization example, run the standalone [Auth0 recipe](../examples/auth0/README.md).
 
-## Browser: ambient context and visible local actions
+## Browser: ambient context and approved workplace actions
 
 ```bash
 npm run dev:web
@@ -52,15 +52,15 @@ Open `http://localhost:3100` and select an incident. Try:
 
 > What is happening with the selected incident? Show an incident card and a timeline.
 
-> Create a follow-up for this incident to investigate the retry spike.
+> Propose a follow-up for this incident to investigate the retry spike. Show me the exact task before it is saved.
 
 > Select the other incident and tell me what changed.
 
-Expected: `incident_card`, `timeline`, `create_followup`, and `select_incident` as appropriate. The selected incident and follow-up list should visibly change. The context is derived from the displayed sample data; local tasks last only for this page session. `propose_action` provides approval UI but does not execute a production action. Web chat does not register Exa search; use Slack or the standalone recipes for that step.
+Expected: `incident_card`, `timeline`, `propose_followup`, `retrieve_followup`, `refresh_followups`, and `select_incident` as appropriate. The context is derived from the displayed sample data and the Ambiguous records retrieved for the selected incident. The agent prepares a proposal; the page approval button performs the write. `propose_action` provides a separate sample approval UI but does not execute a production action. Web chat does not register Exa search; use Slack or the standalone recipes for that step.
 
 ### Add a persistent workplace record
 
-With Ambiguous AI configured, follow [the web template](../templates/web.md#prove-a-record-survives-refresh): propose an exact task in your demo workspace, approve it, create it through the connected MCP tool, and open the returned record link. Refresh the page and retrieve the same ID. Do not use the session-only `create_followup` for this check.
+With Ambiguous AI configured, follow [the web template](../templates/web.md#prove-a-record-survives-refresh): propose an exact task in your demo workspace, approve it with the page button, and open the returned record link if Ambiguous provides one. Refresh the page and retrieve the same ID.
 
 ## Record a focused video
 

--- a/dev-docs/setup.md
+++ b/dev-docs/setup.md
@@ -32,7 +32,7 @@ npm run check-env
 npm run dev
 ```
 
-With no Channel configured, `dev` starts terminal chat. The terminal has your selected model and prompt, but no thread-history, native-card, or Exa search tools. For the sample incident workspace, run `npm run dev:web` and open the URL printed by Next.js. For the React Native template, the same command starts the mobile runtime endpoint; run the Expo app separately from `apps/mobile`.
+With no Channel configured, `dev` starts terminal chat. The terminal has your selected model and prompt, but no thread-history, native-card, or Exa search tools. For the sample incident workspace, run `npm run dev:web` and open `http://127.0.0.1:3100` or `http://localhost:3100`. The web follow-up approval server is loopback-only by default because it can use local Ambiguous credentials. For the React Native template, the same command starts the mobile runtime endpoint; simulators can use the documented localhost/emulator URLs, while physical devices need a deliberate reachable host or deployment.
 
 ## Add Slack
 

--- a/dev-docs/surfaces.md
+++ b/dev-docs/surfaces.md
@@ -6,12 +6,12 @@ Pick the place where your agent's context already exists. The following matrix d
 |---|---|---|---|---|
 | Terminal | `makeAgent`; messages you type | Text and tool output | Ambiguous MCP through shared factory | No Slack history, incident cards, Exa tool, or approval UI |
 | Slack / Teams | `makeAgent`; `read_thread` plus channel context | `incident_card`, `timeline`, `propose_action` | Exa and Ambiguous MCP | Managed Channel setup required; live platform validation required |
-| Web | `makeAgent`; selected sample incident, timeline and follow-ups via `useAgentContext` | Incident cards, timeline, approval UI; `select_incident`, `create_followup` | Ambiguous MCP through shared factory | Local follow-ups reset on refresh; web chat does not register Exa search |
+| Web | `makeAgent`; selected sample incident, timeline and Ambiguous follow-ups via `useAgentContext` | Incident cards, timeline, approval UI; `select_incident`, `propose_followup`, `retrieve_followup`, `refresh_followups` | Ambiguous through the server-side approval boundary | Web chat does not register Exa search or raw workplace write tools; approval server is loopback-only by default |
 | Voice (`/voice`) | Separate `RealtimeAgent`; shares system prompt | Spoken conversation and transcript | Exa via server search route | OpenAI Realtime key required regardless of chat provider; no incident workspace context, workplace MCP, or approval tools |
 | MCP | Host's agent/model; server exposes tools | `incident_card` and HTML UI resource | Exa `search_web` | Does not call `makeAgent`; rendering depends on host; no workplace or approval tools |
 | Mobile | Web runtime's `makeAgent` with a mobile prompt; finance app state through frontend tools | Expo chat, native cards, and `add_mobile_expense` approval UI | OpenAI or OpenRouter through the shared model resolver | Separate install; local sample data only; no bank, messaging, or Realtime voice integration |
 
-Managed `propose_action` posts a nonblocking proposal; its later click reports a decision without automatically resuming the agent. There is no production restart implementation. Nor is it an authorization wrapper around every Ambiguous MCP tool: use an isolated demo workspace and explicitly approve intended writes. Auth0's standalone example separately verifies a machine token and scope before creating its local record.
+Managed `propose_action` posts a nonblocking proposal; its later click reports a decision without automatically resuming the agent. There is no production restart implementation. The web template has its own Ambiguous approval boundary for follow-up tasks; other surfaces that expose Ambiguous MCP should use an isolated demo workspace and enforce required write approval in their own code. Auth0's standalone example separately verifies a machine token and scope before creating its local record.
 
 ## Launch commands
 

--- a/dev-docs/troubleshooting.md
+++ b/dev-docs/troubleshooting.md
@@ -156,6 +156,6 @@ If you genuinely need vitest, `--legacy-peer-deps` gets you past it — put it i
 > still tells you to install `@copilotkit/channels@0.6.1` with
 > `@copilotkit/runtime@1.65.0`. Use the versions in this repo's `package.json`.
 
-## A web follow-up disappears on refresh
+## A web follow-up does not appear after refresh
 
-The sample `create_followup` tool writes browser state only. Use the configured Ambiguous workspace tools for a persistent record and verify its ID after refresh. See [the web template](../templates/web.md#prove-a-record-survives-refresh).
+Only approved Ambiguous records should survive refresh. First confirm `AMBIGUOUS_API_KEY` is set, restart `npm run dev:web`, prepare a proposal, and click **Approve & save to Ambiguous** on the page. Then refresh and use the returned record ID or **Refresh from Ambiguous**. If the provider returns no retrievable record, the persistence check has not passed. See [the web template](../templates/web.md#prove-a-record-survives-refresh).

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,6 +231,7 @@
       "dependencies": {
         "@copilotkit/react-core": "1.70.1",
         "@copilotkit/runtime": "1.70.3",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@openai/agents": "^0.17.2",
         "agent-core": "*",
         "next": "^15.5.0",
@@ -240,7 +241,8 @@
       },
       "devDependencies": {
         "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0"
+        "@types/react-dom": "^19.0.0",
+        "tsx": "^4.20.5"
       }
     },
     "apps/web/node_modules/@copilotkit/runtime": {

--- a/templates/react-native.md
+++ b/templates/react-native.md
@@ -42,7 +42,7 @@ npm run bundle:android
 npm start
 ```
 
-Press `i` for the iOS Simulator or `a` for Android. Set `EXPO_PUBLIC_RUNTIME_URL` in `apps/mobile/.env` when the default URL does not match your target; use the full endpoint path, for example `http://10.0.2.2:3100/api/mobile-copilotkit` for Android. Current main runs Next.js without a forced host binding; use the LAN URL printed by `npm run dev:web` for a physical device, or deploy the runtime first.
+Press `i` for the iOS Simulator or `a` for Android. Set `EXPO_PUBLIC_RUNTIME_URL` in `apps/mobile/.env` when the default URL does not match your target; use the full endpoint path, for example `http://10.0.2.2:3100/api/mobile-copilotkit` for Android. The default `npm run dev:web` binds Next.js to loopback for the web approval demo; for a physical device, explicitly expose a trusted LAN host, use a tunnel/deployment, or run the runtime with the security boundary you intend.
 
 ## What is included
 

--- a/templates/web.md
+++ b/templates/web.md
@@ -22,45 +22,45 @@ npm run check-env
 npm run dev:web
 ```
 
-Open `http://localhost:3100` and select an incident.
+Open `http://127.0.0.1:3100` or `http://localhost:3100` and select an incident. The dev and start scripts bind the credential-backed approval server to loopback by default; keep that boundary unless you add your own authentication and trusted-origin policy.
 
-The page pairs a compact incident view with an always-visible assistant. Start
-with “Summarize this incident” or “Add a follow-up” in chat. Expand **Details &
-timeline** for more context. You can also add follow-ups directly on the page;
-these last only for the current browser session.
+The page pairs a compact incident view with an always-visible assistant. Start with “Summarize this incident” or “Propose a follow-up” in chat. Expand **Details & timeline** for more context. Follow-up writes are two-step: the agent prepares an exact proposal, then the page approval button saves it to Ambiguous and reads it back.
 
 ## What is included
 
-| Piece                      | Implementation                                                                                                                      |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| App and selected record    | [Page](../apps/web/src/app/page.tsx) and [sample data](../apps/web/src/lib/incidents.ts)                                            |
-| Context and local tools    | [AppControl](../apps/web/src/components/app-control.tsx): `useAgentContext`, `select_incident`, and local `create_followup`         |
-| CopilotKit React UI        | [Providers](../apps/web/src/components/providers.tsx) and [generative UI](../apps/web/src/components/generative-ui.tsx)             |
-| Agent endpoint             | [Server runtime](../apps/web/src/app/api/copilotkit/[[...path]]/route.ts)                                                           |
-| Persistent workplace tools | [Ambiguous MCP connection](../packages/agent-core/src/capabilities/workplace.ts), added by the shared agent factory when configured |
+| Piece | Implementation |
+| --- | --- |
+| App and selected record | [Page](../apps/web/src/app/page.tsx) and [sample data](../apps/web/src/lib/incidents.ts) |
+| Context and frontend tools | [AppControl](../apps/web/src/components/app-control.tsx): `useAgentContext`, `select_incident`, `propose_followup`, `retrieve_followup`, and `refresh_followups` |
+| Approval UI and provider reads | [Workplace follow-ups](../apps/web/src/components/workplace-followups.tsx) and [browser client hook](../apps/web/src/lib/use-workplace.ts) |
+| Server approval boundary | [Follow-up API](../apps/web/src/app/api/followups/route.ts) and [service](../apps/web/src/lib/server/followups.ts) |
+| Ambiguous MCP adapter | [Workplace adapter](../apps/web/src/lib/server/workplace.ts), used only after browser approval |
+| CopilotKit React UI | [Generative UI](../apps/web/src/components/generative-ui.tsx) and [providers](../apps/web/src/components/providers.tsx) |
+| Agent endpoint | [Server runtime](../apps/web/src/app/api/copilotkit/[[...path]]/route.ts), configured without raw workplace write tools |
 
-`create_followup` changes only browser state. For the persistent path, explicitly use the connected **Ambiguous workspace's task tools**, which store the record outside the page. Their schemas come from the MCP server; discover them instead of inventing a tool name or URL.
+The web chat does not receive raw Ambiguous write tools. It can propose a task and read or refresh existing records through frontend tools; the server writes only after the user clicks **Approve & save to Ambiguous**. Tool schemas come from the MCP server at write time, and returned links must come from Ambiguous rather than being invented.
 
 ## Prove a record survives refresh
 
 1. Ask: “What is happening with the selected incident? Use the page context.” Check its answer against the incident currently selected.
-2. Ask: “Propose a task in our Ambiguous workspace to investigate the selected incident. Show the exact title and details for approval. Do not use the session-only create_followup tool.”
-3. Approve that specific demo-workspace write. Ask the agent to create it with the connected workplace tool, then return its actual ID and record link. Open the link and inspect the saved fields.
-4. Refresh the browser. Ask the agent to retrieve the saved task by its ID from Ambiguous. Check it returns the same record without creating a duplicate.
+2. Ask: “Propose a task in our Ambiguous workspace to investigate the selected incident. Show the exact title and details for approval.”
+3. Review the page proposal. Click **Approve & save to Ambiguous** only if the fields are correct. The app should return the actual record ID and any provider link.
+4. Refresh the browser. Ask the agent to retrieve the saved task by its ID from Ambiguous, or click **Refresh from Ambiguous**. Check the same record returns without creating a duplicate.
+5. Repeat with **Decline** and confirm no task is created.
 
-If only a local follow-up appears or the tool returns no retrievable record, the persistence check has not passed. Do not manufacture a URL. The shared MCP connection is implemented; live workspace access and writes require your account. The reference approval UI is not a hard authorization wrapper around every MCP call.
+If there is no retrievable Ambiguous record, the persistence check has not passed. Offline tests cover proposal validation, session binding, approval/deny behavior, read-back, duplicate prevention, expiry preflight, provider schema drift, sanitized provider errors, and the cleanup path. Live workspace access and writes still require your account. Provider outage/recovery and a fresh live expiry rehearsal are separate live checks.
 
 ## Give this to your coding agent
 
 ```text
 Read the root hackathon overview, rules, sponsor guide, and AGENTS.md.
 Adapt apps/web to our user and workflow. Keep CopilotKit React for page context,
-frontend tools, and agent-rendered UI. Use Ambiguous AI for persistent records.
-Rename or remove the sample session-only create_followup so users cannot confuse
-it with saving a workplace task. Return the real record ID/link and verify read-
-back after refresh. Keep credentials server-side and enforce any required
-approval immediately before writes. Run npm run verify and npm run build
---workspace web, then document the live record create/read check.
+frontend tools, agent-rendered UI, and page approval. Use Ambiguous AI for
+persistent records. Do not expose raw write tools to the web chat when the page
+approval path is required. Return the real record ID/link and verify read-back
+after refresh. Keep credentials server-side and enforce authorization at the
+write boundary. Run npm run verify and npm run build --workspace web, then
+document the live record create/read/decline checks.
 ```
 
 [CopilotKit docs](https://docs.copilotkit.ai/) · [Sponsor authentication and first calls](../using-sponsor-tools.md) · [Demo prompts](../dev-docs/demo-prompts.md)

--- a/using-sponsor-tools.md
+++ b/using-sponsor-tools.md
@@ -77,7 +77,7 @@ npm run dev:slack
 
 Invite the bot and add a few facts to a thread before asking: “Read this thread and show an incident card.” **Check:** `read_thread` uses earlier messages and `incident_card` renders in Slack. Customize [the Channel](apps/channel-slack/src/channel.tsx), [tools](apps/channel-slack/src/tools.tsx), and [components](apps/channel-slack/src/components.tsx).
 
-**First call, React web:** run `npm run dev:web`, open `http://localhost:3100`, select an incident, then ask: “What is happening with the selected incident? Show a card.” **Check:** the answer matches the current page without pasting its contents. [AppControl](apps/web/src/components/app-control.tsx) registers page context and frontend tools; [GenerativeUI](apps/web/src/components/generative-ui.tsx) registers React components.
+**First call, React web:** run `npm run dev:web`, open `http://localhost:3100`, select an incident, then ask: “What is happening with the selected incident? Show a card.” **Check:** the answer matches the current page without pasting its contents. [AppControl](apps/web/src/components/app-control.tsx) registers page context and frontend tools; [GenerativeUI](apps/web/src/components/generative-ui.tsx) registers React components. With Ambiguous configured, ask for a follow-up proposal, approve it in the page, then refresh and read back the same provider record.
 
 **First call, React Native:** run `npm run dev:web`, then `npm ci --prefix apps/mobile` and `npm start --prefix apps/mobile`. Ask “Show my balances.” **Check:** the app uses its local finance state and renders the native account card. The sample expense write waits for an approval tap and changes in-memory data only.
 
@@ -198,7 +198,7 @@ console.log(await response.json());
 JS
 ```
 
-**Check:** the returned identity belongs to the intended demo workspace. Then run `npm run dev:web` and follow [the web template's create/read-back sequence](templates/web.md#prove-a-record-survives-refresh). Ask for the exact proposed task, approve it, create it through the connected MCP tools, and retrieve the same ID after refreshing. Open the actual returned record link. Do not confuse this with the browser-only `create_followup` tool.
+**Check:** the returned identity belongs to the intended demo workspace. Then run `npm run dev:web` and follow [the web template's create/read-back sequence](templates/web.md#prove-a-record-survives-refresh). Ask for the exact proposed task, approve it with the page button, and retrieve the same ID after refreshing. Open the actual returned record link. The web chat proposes and reads through frontend tools; it does not receive raw Ambiguous write tools.
 
 The [shared MCP connection](packages/agent-core/src/capabilities/workplace.ts) is also available to Slack and terminal chat when configured. Tool schemas come from the live workspace; never invent names, arguments, or record URLs. Approval prompts and cards guide behavior but do not enforce a gate around every MCP tool. For your own app, enforce required authorization at the write boundary. A `401` needs valid credentials; a `403` needs appropriate permissions. A new workspace does not fix access to the intended one.
 


### PR DESCRIPTION
Web follow-ups currently disappear on refresh. This change lets the assistant prepare an Ambiguous task for review, saves it only when the user approves the exact fields in the page, and reads the provider record back after saving or reloading.

The integration preserves the simplified incident UI and the merged React Native runtime. Proposals expire after ten minutes and are bound to the browser session and workspace identity. Approval metadata is stored locally; saved tasks come from Ambiguous. The web agent cannot bypass the page approval through raw MCP write tools. Development and production start commands bind to loopback, with the resulting mobile device setup documented.

Validation at `06e0415`:

- Clean install, root typecheck and local verification pass. The web suite has 34 passing tests covering approval/denial, persistence/readback, session and workspace binding, expiry, concurrent approval, uncertain writes, provider failures and cleanup errors.
- Web production build passes, including the web approval and mobile runtime routes. The existing Google Vertex dynamic import warning remains.
- Independent review found and fixed a provider cleanup failure that could mask the response; both successful and failed requests have regression coverage.
- Fresh live OpenAI/Ambiguous validation passed: page context and native card, exact proposal approval, provider readback, persistence in a fresh browser page, assistant retrieval, and decline without a write.
- A deliberately invalid provider credential produced a sanitized pre-write error; restoring configuration allowed the same proposal to save exactly one matching task. An unchanged proposal was rejected after its actual ten-minute expiry, with no write attempt or provider task. This tests pre-write authentication failure, not an uncertain failure after sending a write. Ambiguous returned no record URL; the UI displayed its actual ID without inventing a link.

Slack completion is tracked independently in #8. The deferred WhatsApp work is preserved separately in #9.
