### PR TITLE
Simplify the web example UI and UX

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,6 +1,7 @@
+/* Calm defaults shared by the web example, voice page, and agent cards. */
 :root {
-  --ground: #dedee9;
-  --surface: rgba(255, 255, 255, 0.5);
+  --ground: #ededf5;
+  --surface: #fff;
   --border: #dbdbe5;
   --text: #010507;
   --muted: #57575b;
@@ -19,16 +20,20 @@ body {
   line-height: 1.6;
 }
 button,
-input {
+input,
+select {
   font: inherit;
 }
-button {
+button,
+summary,
+select {
   cursor: pointer;
 }
 button:focus-visible,
 input:focus-visible,
+select:focus-visible,
 summary:focus-visible {
-  outline: 2px solid #010507;
+  outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
 code,
@@ -43,226 +48,117 @@ p {
   margin-top: 0;
 }
 .ck-workspace {
-  min-height: 100vh;
-  position: relative;
-  overflow: hidden;
-  padding: 8px 8px 80px;
-}
-.ck-atmosphere {
-  pointer-events: none;
-}
-.ck-atmosphere i {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(103px);
-  z-index: 0;
-  width: 446px;
-  height: 446px;
-  background: rgba(255, 172, 77, 0.2);
-}
-.ck-atmosphere i:nth-child(1) {
-  left: 1040px;
-  top: 11px;
-}
-.ck-atmosphere i:nth-child(2) {
-  left: 1339px;
-  top: 625px;
-  width: 609px;
-  height: 609px;
-  background: #c9c9da;
-}
-.ck-atmosphere i:nth-child(3) {
-  left: 670px;
-  top: -365px;
-  width: 609px;
-  height: 609px;
-  background: #c9c9da;
-}
-.ck-atmosphere i:nth-child(4) {
-  left: 508px;
-  top: 702px;
-  width: 609px;
-  height: 609px;
-  background: #f3f3fc;
-}
-.ck-atmosphere i:nth-child(5) {
-  left: 128px;
-  top: 331px;
-  background: rgba(255, 243, 136, 0.3);
-}
-.ck-atmosphere i:nth-child(6) {
-  left: -205px;
-  top: 803px;
+  max-width: 1160px;
+  margin: auto;
+  padding: 48px 32px;
 }
 .ck-workspace-header {
-  position: relative;
-  z-index: 1;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  max-width: 1440px;
-  margin: auto;
-  padding: 24px 16px 32px;
+  gap: 24px;
+  margin-bottom: 32px;
 }
 .ck-eyebrow {
   font-size: 12px;
   color: var(--muted);
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 .ck-workspace h1 {
   font-size: 32px;
-  line-height: 36px;
-  font-weight: 300;
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: -0.04em;
   margin: 0;
 }
+.ck-intro {
+  color: var(--muted);
+  margin: 12px 0 0;
+}
+.ck-tag {
+  flex-shrink: 0;
+  font-size: 12px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--muted);
+  white-space: nowrap;
+}
 .ck-workspace-grid {
-  position: relative;
-  z-index: 1;
   display: grid;
-  grid-template-columns: 240px minmax(0, 1fr) 280px;
-  gap: 8px;
-  max-width: 1440px;
-  margin: auto;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 24px;
   align-items: start;
 }
 .ck-panel {
-  position: relative;
-  z-index: 1;
-  background: rgba(255, 255, 255, 0.5);
-  border: 2px solid #fff;
-  border-radius: 8px;
-  padding: 24px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 28px;
   min-width: 0;
 }
-.ck-incident-list {
-  padding: 16px;
-}
-.ck-section-label {
+.ck-incident-picker {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font:
-    400 10px "Spline Sans Mono",
-    monospace;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--muted);
-  margin: 0 0 16px;
+  gap: 16px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--border);
 }
-.ck-section-label > span:not(.ck-tag) {
+.ck-incident-picker label {
+  font-size: 12px;
+  color: var(--muted);
+}
+.ck-incident-picker select {
   flex: 1;
-  height: 1px;
-  background: var(--border);
-}
-.ck-muted {
-  color: var(--muted);
-  font-size: 12px;
-}
-.ck-incident {
-  text-align: left;
-  width: 100%;
-  background: transparent;
-  border: 0;
-  border-radius: 4px;
-  padding: 12px;
-  margin-bottom: 4px;
-  color: var(--text);
-}
-.ck-incident:hover {
-  background: rgba(255, 255, 255, 0.5);
-}
-.ck-incident[aria-pressed="true"] {
-  background: rgba(255, 255, 255, 0.7);
-}
-.ck-incident strong {
-  display: block;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 1.25;
-  margin: 12px 0 8px;
-}
-.ck-incident-meta {
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px;
-  color: var(--muted);
-}
-.ck-tag {
-  display: inline-block;
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 1.4;
-  padding: 2px 6px;
-  border-radius: 9999px;
-  background: rgba(255, 255, 255, 0.65);
-  color: var(--text);
-  white-space: nowrap;
-}
-.ck-incident[aria-pressed="true"] .ck-tag {
-  background: #010507;
-  color: white;
-}
-.ck-context-note {
-  margin-top: 32px;
-  font-size: 12px;
-  border-top: 1px solid var(--border);
-  padding-top: 16px;
-}
-.ck-context-note p {
-  margin: 8px 0 0;
-  color: var(--muted);
-}
-.ck-dot {
-  display: inline-block;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: #189370;
-  margin-right: 4px;
-}
-.ck-incident-body {
-  display: grid;
-  gap: 8px;
   min-width: 0;
+  max-width: 100%;
+  color: var(--text);
+  background: #f7f7f9;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px;
+}
+.ck-detail {
+  padding: 24px 0;
+}
+.ck-status-label {
+  display: inline-block;
+  color: var(--muted);
+  font-size: 12px;
+  margin-bottom: 12px;
 }
 .ck-detail h2 {
-  margin: 24px 0 12px;
   font-size: 24px;
   font-weight: 500;
-  line-height: 28px;
+  line-height: 1.35;
+  letter-spacing: -0.025em;
+  margin-bottom: 12px;
 }
-.ck-detail > p {
+.ck-detail p {
   color: var(--muted);
+  margin-bottom: 16px;
+}
+.ck-more summary {
+  font-size: 12px;
+  padding: 8px 0;
+}
+.ck-more h3 {
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 8px;
 }
 .ck-detail-facts {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 16px;
-  margin: 24px 0;
+  margin: 16px 0 24px;
+  font-size: 12px;
 }
 .ck-detail-facts dt {
   color: var(--muted);
-  font-size: 12px;
 }
 .ck-detail-facts dd {
   margin: 4px 0 0;
-}
-.ck-impact {
-  border-top: 1px solid var(--border);
-  padding-top: 16px;
-}
-.ck-impact h3 {
-  font-size: 12px;
-  font-weight: 600;
-  margin-bottom: 4px;
-}
-.ck-impact p {
-  margin: 0;
-  font-size: 14px;
 }
 .ck-timeline {
   padding: 0;
@@ -271,46 +167,54 @@ p {
 }
 .ck-timeline li {
   display: grid;
-  grid-template-columns: 88px minmax(0, 1fr);
-  gap: 16px;
-  padding-bottom: 20px;
-}
-.ck-timeline li:last-child {
-  padding-bottom: 0;
+  grid-template-columns: 80px minmax(0, 1fr);
+  gap: 12px;
+  padding-top: 12px;
+  font-size: 12px;
 }
 .ck-timeline time {
   color: var(--muted);
+  font-size: 10px;
   padding-top: 2px;
 }
 .ck-timeline strong {
-  font-size: 12px;
-  font-weight: 600;
+  font-weight: 500;
 }
 .ck-timeline p {
   margin: 4px 0 0;
-  color: var(--muted);
+}
+.ck-followups {
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+}
+.ck-followups h2,
+.ck-assistant-header h2 {
+  font-size: 16px;
+  line-height: 1.4;
+  font-weight: 600;
+  margin: 0 0 8px;
 }
 .ck-task-list {
   list-style: none;
   padding: 0;
+  margin: 16px 0;
 }
 .ck-task-list li {
   display: flex;
+  align-items: baseline;
   gap: 12px;
-  padding: 12px 0;
-  border-bottom: 1px solid var(--border);
+  padding: 10px 0;
   overflow-wrap: anywhere;
 }
+.ck-task-list li + li {
+  border-top: 1px solid var(--border);
+}
 .ck-empty {
-  padding: 16px 0;
   color: var(--muted);
-}
-.ck-task-form label {
-  display: block;
   font-size: 12px;
-  margin-bottom: 8px;
+  margin-bottom: 16px;
 }
-.ck-task-form > div {
+.ck-task-form {
   display: flex;
   gap: 8px;
 }
@@ -318,68 +222,57 @@ p {
   width: 100%;
   min-width: 0;
   border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.7);
-  border-radius: 4px;
-  padding: 8px 12px;
+  background: var(--surface);
+  border-radius: 8px;
+  padding: 10px 12px;
   color: var(--text);
 }
-.ck-task-form button {
-  white-space: nowrap;
+.ck-task-form .ck-btn {
+  padding: 10px 16px;
+  border-radius: 8px;
 }
+.ck-local-note,
 .ck-notice {
-  min-height: 16px;
   font-size: 12px;
-  margin: 8px 0 0;
+  margin: 10px 0 0;
   color: var(--muted);
 }
-.ck-guide h3 {
-  font-size: 20px;
-  line-height: 24px;
-  font-weight: 500;
+.ck-notice:empty {
+  margin: 0;
 }
-.ck-guide ol {
+.ck-assistant {
+  display: flex;
+  flex-direction: column;
+  height: 600px;
+  height: min(680px, max(510px, calc(100dvh - 230px)));
   padding: 0;
-  list-style: none;
-  counter-reset: prompts;
+  overflow: hidden;
 }
-.ck-guide li {
-  padding: 16px 0;
+.ck-assistant-header {
+  padding: 24px 28px;
   border-bottom: 1px solid var(--border);
-  counter-increment: prompts;
 }
-.ck-guide li strong {
-  font-weight: 500;
-}
-.ck-guide li strong::before {
-  content: "0" counter(prompts) " / ";
-  font:
-    12px "Spline Sans Mono",
-    monospace;
+.ck-assistant-header p {
+  font-size: 12px;
+  margin: 0;
   color: var(--muted);
 }
-.ck-guide li p {
-  margin: 8px 0;
-  font-size: 12px;
+.ck-chat {
+  flex: 1;
+  min-height: 0;
 }
-.ck-guide li code {
-  color: var(--muted);
-  font-size: 10px;
+.ck-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
-.ck-guide details {
-  font-size: 12px;
-}
-.ck-guide summary {
-  cursor: pointer;
-}
-.ck-guide details p {
-  margin: 12px 0;
-}
-.ck-guide-footer {
-  color: var(--muted);
-  font-size: 12px;
-  margin: 24px 0 0;
-}
-/* Shared voice surface and agent cards. */
+/* The optional voice example uses the same basic page frame. */
 .ck-page {
   max-width: 46rem;
   margin: auto;
@@ -388,48 +281,45 @@ p {
 .ck-dek {
   color: var(--muted);
 }
-@media (max-width: 1100px) {
-  .ck-workspace-grid {
-    grid-template-columns: 220px minmax(0, 1fr);
-  }
-  .ck-guide {
-    grid-column: 1 / -1;
-  }
-  .ck-guide ol {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0 24px;
-  }
-}
-@media (max-width: 640px) {
-  .ck-workspace-header {
-    padding: 24px 8px;
+@media (max-width: 800px) {
+  .ck-workspace {
+    padding: 32px 20px;
   }
   .ck-workspace-grid {
     grid-template-columns: minmax(0, 1fr);
+    gap: 16px;
+  }
+  .ck-assistant {
+    height: 560px;
+  }
+}
+@media (max-width: 480px) {
+  .ck-workspace {
+    padding: 24px 16px;
+  }
+  .ck-workspace-header {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-bottom: 24px;
+  }
+  .ck-workspace h1 {
+    font-size: 28px;
   }
   .ck-panel {
-    padding: 16px;
+    padding: 20px;
   }
-  .ck-incident-list .ck-context-note {
-    margin-top: 16px;
+  .ck-detail h2 {
+    font-size: 22px;
   }
   .ck-detail-facts {
-    grid-template-columns: 1fr;
-    gap: 12px;
+    grid-template-columns: 1fr 1fr;
   }
-  .ck-guide ol {
-    display: block;
+  .ck-assistant {
+    padding: 0;
   }
-  .ck-timeline li {
-    grid-template-columns: 72px minmax(0, 1fr);
-    gap: 12px;
-  }
-  .ck-timeline time {
-    font-size: 10px;
-  }
-  .ck-task-form > div {
-    flex-wrap: wrap;
+  .ck-assistant-header {
+    padding: 20px;
   }
 }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,9 +4,8 @@ import "@copilotkit/react-core/v2/styles.css";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Agents, Everywhere — web surface",
-  description:
-    "An incident workspace with shared context, native agent UI, and local follow-ups.",
+  title: "Incident assistant — Agents, Everywhere",
+  description: "Pick an incident, ask your assistant, and add a follow-up.",
 };
 
 export default function RootLayout({

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useCallback, useState, type FormEvent } from "react";
-import { CopilotSidebar } from "@copilotkit/react-core/v2";
+import {
+  CopilotChat,
+  useConfigureSuggestions,
+} from "@copilotkit/react-core/v2";
 import { GenerativeUI } from "@/components/generative-ui";
 import { AppControl } from "@/components/app-control";
 import {
@@ -27,9 +30,29 @@ export default function Home() {
   const addFollowup = useCallback((incidentId: string, nextTitle: string) => {
     const task = createFollowup(incidentId, nextTitle, crypto.randomUUID());
     setFollowups((current) => [...current, task]);
-    setNotice(`Added a local follow-up to ${task.incidentId}.`);
+    setNotice(`Added a follow-up to ${task.incidentId}.`);
     return task;
   }, []);
+
+  useConfigureSuggestions(
+    {
+      suggestions: [
+        {
+          title: "Summarize this incident",
+          message:
+            "Summarize the selected incident using the page context. What needs attention?",
+        },
+        {
+          title: "Add a follow-up",
+          message:
+            "Add one useful local follow-up for the selected incident based on its current status.",
+        },
+      ],
+      available: "before-first-message",
+    },
+    [],
+  );
+
   function submitFollowup(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     try {
@@ -52,112 +75,73 @@ export default function Home() {
         addFollowup={addFollowup}
       />
       <main className="ck-workspace">
-        <div className="ck-atmosphere" aria-hidden="true">
-          {Array.from({ length: 6 }, (_, i) => (
-            <i key={i} />
-          ))}
-        </div>
         <header className="ck-workspace-header">
           <div>
-            <p className="ck-eyebrow">Agents, everywhere / Web workspace</p>
-            <h1>Incident room</h1>
+            <p className="ck-eyebrow">Agents, everywhere · Web example</p>
+            <h1>Incident assistant</h1>
+            <p className="ck-intro">
+              Pick an incident. Ask your assistant. Add a follow-up.
+            </p>
           </div>
           <span className="ck-tag">Sample data</span>
         </header>
+
         <div className="ck-workspace-grid">
-          <aside
-            className="ck-panel ck-incident-list"
-            aria-label="Incident selection"
-          >
-            <h2 className="ck-section-label">
-              Incidents <span />
-            </h2>
-            <p className="ck-muted">
-              Pick an incident. Your agent sees the same context you do.
-            </p>
-            {incidents.map((item) => (
-              <button
-                type="button"
-                className="ck-incident"
-                aria-pressed={selectedId === item.id}
-                key={item.id}
-                onClick={() => selectIncident(item.id)}
+          <section className="ck-panel" aria-labelledby="incident-title">
+            <div className="ck-incident-picker">
+              <label htmlFor="incident-select">Incident</label>
+              <select
+                id="incident-select"
+                value={selectedId}
+                onChange={(event) => selectIncident(event.target.value)}
               >
-                <span className="ck-incident-meta">
-                  <code>{item.id}</code>
-                  <span className="ck-tag">{item.severity}</span>
-                </span>
-                <strong>{item.title}</strong>
-                <span className="ck-muted">
-                  {item.status} · {item.service}
-                </span>
-              </button>
-            ))}
-            <div className="ck-context-note">
-              <span className="ck-dot" /> Context follows your selection
-              <p>
-                The selected incident, timeline, and follow-ups are shared with
-                the agent automatically.
-              </p>
+                {incidents.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.id} · {item.service}
+                  </option>
+                ))}
+              </select>
             </div>
-          </aside>
-          <div className="ck-incident-body">
-            <section
-              className="ck-panel ck-detail"
-              aria-labelledby="incident-title"
-            >
-              <div className="ck-incident-meta">
-                <code>
-                  {incident.id} · {incident.channel}
-                </code>
-                <span className="ck-tag">{incident.status}</span>
-              </div>
+
+            <div className="ck-detail">
+              <span className="ck-status-label">{incident.status}</span>
               <h2 id="incident-title">{incident.title}</h2>
               <p>{incident.summary}</p>
-              <dl className="ck-detail-facts">
-                <div>
-                  <dt>Service</dt>
-                  <dd>{incident.service}</dd>
-                </div>
-                <div>
-                  <dt>Incident lead</dt>
-                  <dd>{incident.owner}</dd>
-                </div>
-                <div>
-                  <dt>Last update</dt>
-                  <dd>{incident.updated}</dd>
-                </div>
-              </dl>
-              <div className="ck-impact">
-                <h3>Observed impact</h3>
+              <details className="ck-more" key={incident.id}>
+                <summary>Details &amp; timeline</summary>
+                <dl className="ck-detail-facts">
+                  <div>
+                    <dt>Incident lead</dt>
+                    <dd>{incident.owner}</dd>
+                  </div>
+                  <div>
+                    <dt>Severity</dt>
+                    <dd>{incident.severity}</dd>
+                  </div>
+                  <div>
+                    <dt>Last update</dt>
+                    <dd>{incident.updated}</dd>
+                  </div>
+                </dl>
+                <h3>Impact</h3>
                 <p>{incident.impact}</p>
-              </div>
-            </section>
-            <section className="ck-panel" aria-labelledby="timeline-title">
-              <h2 className="ck-section-label" id="timeline-title">
-                Timeline <span />
-              </h2>
-              <ol className="ck-timeline">
-                {incident.timeline.map((event) => (
-                  <li key={event.time}>
-                    <time>{event.time} UTC</time>
-                    <div>
-                      <strong>{event.author}</strong>
-                      <p>{event.detail}</p>
-                    </div>
-                  </li>
-                ))}
-              </ol>
-            </section>
-            <section className="ck-panel" aria-labelledby="followup-title">
-              <h2 className="ck-section-label" id="followup-title">
-                Follow-ups <span />
-                <span className="ck-tag">{visibleTasks.length} local</span>
-              </h2>
-              <p className="ck-muted">
-                This page session only. Refreshing clears tasks; no external
-                system is updated.
-              </p>
+                <h3>Timeline</h3>
+                <ol className="ck-timeline">
+                  {incident.timeline.map((event) => (
+                    <li key={event.time}>
+                      <time>{event.time} UTC</time>
+                      <div>
+                        <strong>{event.author}</strong>
+                        <p>{event.detail}</p>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </details>
+            </div>
+
+            <section className="ck-followups" aria-labelledby="followup-title">
+              <h2 id="followup-title">Follow-ups</h2>
               {visibleTasks.length ? (
                 <ul className="ck-task-list">
                   {visibleTasks.map((task) => (
@@ -169,92 +153,52 @@ export default function Home() {
                 </ul>
               ) : (
                 <p className="ck-empty">
-                  No follow-ups yet. Add one here or ask the agent.
+                  No follow-ups yet. Ask the assistant or add one.
                 </p>
               )}
               <form onSubmit={submitFollowup} className="ck-task-form">
-                <label htmlFor="task-title">
+                <label className="ck-sr-only" htmlFor="task-title">
                   New follow-up for {incident.id}
                 </label>
-                <div>
-                  <input
-                    id="task-title"
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                    maxLength={200}
-                    placeholder="e.g. Compare connection pool metrics"
-                    required
-                  />
-                  <button className="ck-btn ck-btn--primary" type="submit">
-                    Add task
-                  </button>
-                </div>
+                <input
+                  id="task-title"
+                  value={title}
+                  onChange={(event) => setTitle(event.target.value)}
+                  maxLength={200}
+                  placeholder="Write a follow-up…"
+                  required
+                />
+                <button className="ck-btn ck-btn--primary" type="submit">
+                  Add
+                </button>
               </form>
+              <p className="ck-local-note">
+                Saved for this session. Cleared on refresh.
+              </p>
               <p role="status" className="ck-notice">
                 {notice}
               </p>
             </section>
-          </div>
-          <aside className="ck-panel ck-guide" aria-label="Agent demo prompts">
-            <h2 className="ck-section-label">
-              Put context to work <span />
-            </h2>
-            <h3>Bring the agent into the room.</h3>
-            <p className="ck-muted">
-              Open the chat to try these prompts with your configured model
-              provider.
-            </p>
-            <ol>
-              <li>
-                <strong>Read the room</strong>
-                <p>
-                  “Show an incident card for the selected incident, using what
-                  you can see.”
-                </p>
-                <code>incident_card</code>
-              </li>
-              <li>
-                <strong>Connect the events</strong>
-                <p>
-                  “Draw a timeline and separate observations from possible
-                  causes.”
-                </p>
-                <code>timeline</code>
-              </li>
-              <li>
-                <strong>Take a local action</strong>
-                <p>“Add a follow-up to check the metrics for this incident.”</p>
-                <code>create_followup</code>
-              </li>
-              <li>
-                <strong>Move with the work</strong>
-                <p>
-                  “Switch to{" "}
-                  {selectedId === "INC-1042" ? "INC-1043" : "INC-1042"} and
-                  summarize what changed.”
-                </p>
-                <code>select_incident</code>
-              </li>
-            </ol>
-            <details>
-              <summary>Try an approval card</summary>
-              <p>
-                “Use propose_action to ask me to approve a sample rollback. Do
-                not execute it.”
-              </p>
-              <p>
-                An approval card records a decision. This workspace has no
-                production rollback tool.
-              </p>
-            </details>
-            <p className="ck-guide-footer">
-              You can select incidents and add local tasks without API
-              credentials.
-            </p>
-          </aside>
+          </section>
+
+          <section
+            className="ck-panel ck-assistant"
+            aria-labelledby="assistant-title"
+          >
+            <header className="ck-assistant-header">
+              <h2 id="assistant-title">Ask assistant</h2>
+              <p>It can read this incident and add follow-ups.</p>
+            </header>
+            <CopilotChat
+              className="ck-chat"
+              labels={{
+                welcomeMessageText: "What needs attention?",
+                chatInputPlaceholder: "Ask about this incident…",
+              }}
+            />
+          </section>
         </div>
       </main>
-      <CopilotSidebar />
     </>
   );
 }

--- a/templates/web.md
+++ b/templates/web.md
@@ -24,14 +24,19 @@ npm run dev:web
 
 Open `http://localhost:3100` and select an incident.
 
+The page pairs a compact incident view with an always-visible assistant. Start
+with “Summarize this incident” or “Add a follow-up” in chat. Expand **Details &
+timeline** for more context. You can also add follow-ups directly on the page;
+these last only for the current browser session.
+
 ## What is included
 
-| Piece | Implementation |
-|---|---|
-| App and selected record | [Page](../apps/web/src/app/page.tsx) and [sample data](../apps/web/src/lib/incidents.ts) |
-| Context and local tools | [AppControl](../apps/web/src/components/app-control.tsx): `useAgentContext`, `select_incident`, and local `create_followup` |
-| CopilotKit React UI | [Providers](../apps/web/src/components/providers.tsx) and [generative UI](../apps/web/src/components/generative-ui.tsx) |
-| Agent endpoint | [Server runtime](../apps/web/src/app/api/copilotkit/[[...path]]/route.ts) |
+| Piece                      | Implementation                                                                                                                      |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| App and selected record    | [Page](../apps/web/src/app/page.tsx) and [sample data](../apps/web/src/lib/incidents.ts)                                            |
+| Context and local tools    | [AppControl](../apps/web/src/components/app-control.tsx): `useAgentContext`, `select_incident`, and local `create_followup`         |
+| CopilotKit React UI        | [Providers](../apps/web/src/components/providers.tsx) and [generative UI](../apps/web/src/components/generative-ui.tsx)             |
+| Agent endpoint             | [Server runtime](../apps/web/src/app/api/copilotkit/[[...path]]/route.ts)                                                           |
 | Persistent workplace tools | [Ambiguous MCP connection](../packages/agent-core/src/capabilities/workplace.ts), added by the shared agent factory when configured |
 
 `create_followup` changes only browser state. For the persistent path, explicitly use the connected **Ambiguous workspace's task tools**, which store the record outside the page. Their schemas come from the MCP server; discover them instead of inventing a tool name or URL.


### PR DESCRIPTION
The web example opened an incident list, detail panels, a long prompt guide, and chat at once. Simplify it to a compact incident view beside an inline assistant, with a dropdown for switching incidents and expandable details and timeline.

Replace the prompt guide with two chat starters, shorten the follow-up form and copy, and simplify the responsive styling. Page context, frontend tools, agent-rendered cards, and session-only follow-ups retain their existing behavior. Update the page metadata and template guide to match.

Validation:
- Prettier and diff hygiene checks.
- All workspace typechecks and root tests; MCP stdio protocol check.
- Production web build (passes with the dependency-expression warning in the Google Vertex SDK dependency).
- Browser checks for selection, follow-up creation and validation, refresh behavior, chat starters, and desktop/mobile layouts at 320px and 390px.

Live assistant responses were not tested because this checkout has no model credentials configured.
