### PR TITLE
Remove template numbers from app README titles

### DIFF
--- a/apps/channel/README.md
+++ b/apps/channel/README.md
@@ -1,4 +1,4 @@
-# Template 1: Slack thread agent
+# Slack thread agent
 
 **OpenAI + CopilotKit Channels + Exa**
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,4 +1,4 @@
-# Template 3: React Native agent
+# React Native agent
 
 **OpenAI or OpenRouter + CopilotKit React Native**
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,4 +1,4 @@
-# Template 2: An agent inside your web app
+# An agent inside your web app
 
 **OpenAI + CopilotKit React + Ambiguous AI**
 


### PR DESCRIPTION
Remove the “Template 1”, “Template 2”, and “Template 3” prefixes from the individual app README titles.

Validation: root typecheck passed; verified that only the first line of each app README changed.
