### PR TITLE
docs: use official onboarding prompts in the starter

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -8,19 +8,24 @@ there is nothing to keep in sync.
   "common mistakes" list that will save you an hour. Vendored from
   [CopilotKit/channels-sdk](https://github.com/CopilotKit/channels-sdk).
 
-To add the rest of the CopilotKit skills (setup, develop, integrations, debug,
-upgrade, agui):
+Use [the onboarding paths in the root README](../../README.md#copilotkit-onboarding)
+for account/project setup and a verified integration. To install the current
+CopilotKit development skills without starting onboarding:
 
 ```sh
-npx skills add copilotkit/skills --full-depth -y
+npx --yes copilotkit@latest skills install -y
 ```
 
-To install the Slack setup workflow as a skill in whatever coding agent you are
-already running:
+To install the maintained Channels setup skill and print its onboarding prompt:
 
 ```sh
-npx copilotkit@latest skills install --skill setup-slack-channel -y
+npm run channel:setup -- --no-clipboard
 ```
+
+Continue with the emitted prompt in the same coding-agent session. Select Slack
+and connect `apps/channel`; the installed skill is named `channels-setup`.
+It handles provisioning, while the bundled `build-channels-agent` skill documents
+the tested SDK APIs. Installing skills alone does not connect the app.
 
 `.mcp.json` at the repo root also wires the CopilotKit docs MCP server and Exa's
 hosted MCP into your coding agent, so it can look things up live rather than

--- a/.agents/skills/build-channels-agent/SKILL.md
+++ b/.agents/skills/build-channels-agent/SKILL.md
@@ -90,8 +90,9 @@ most likely reason a correct-looking Channel refuses to typecheck.
 Standalone `@copilotkit/channels-ui` / `-slack` / `-teams` / … packages also
 exist and work, but the single umbrella dependency is the documented path.
 
-**A CopilotKit Intelligence API key is required** (free tier available). There is
-no standalone or DIY way to run a Channel.
+**This starter's managed Channel requires a CopilotKit Intelligence API key.**
+The [current Slack docs](https://docs.copilotkit.ai/slack) describe other runner
+and hosting options.
 
 **Reference app:** [OpenTag](https://github.com/CopilotKit/OpenTag) is a
 complete, real agent built on this SDK. When a task is close to "a full Slack
@@ -158,9 +159,10 @@ from `@copilotkit/channels`) pointed at your agent's URL.
 
 ### Direct adapter — only when you own the platform connection
 
-Pass `adapters` when *you* hold the platform tokens. This is the secondary path:
-platform secrets in your app and per-platform wiring in code. It does **not**
-avoid needing Intelligence — the runtime still owns the lifecycle.
+Pass `adapters` when *you* hold the platform tokens. This puts platform secrets
+in your app and per-platform wiring in code. Running your own Channel runner is
+a separate hosting choice; see the current Slack docs for those options. This
+starter uses the managed Intelligence runtime.
 
 Do not reach for this because a managed Channel reports `setup_required` or
 because the dashboard is unfamiliar. Swapping to a direct adapter to "make it

--- a/.agents/skills/build-channels-agent/SKILL.md
+++ b/.agents/skills/build-channels-agent/SKILL.md
@@ -28,13 +28,12 @@ anything remembered.
 > `BotToolContext`) and they exist **nowhere** in the shipped packages —
 > importing them fails to compile. Name your variable `channel`, not `bot`.
 
-**Every code sample here compiles.** They were transcribed into one project and
-typechecked under `strict` against both `@copilotkit/channels@0.7.1` +
-`@copilotkit/runtime@1.66.1` and the `0.6.1` + `1.65.0` pair that the
-[Slack guide](https://docs.copilotkit.ai/slack) pins — zero errors on both. Every
-API here exists in both versions except `defineChannelComponent` and the
-native-node helpers, which are **0.7+ only**. Channels and Runtime ship as a pair —
-upgrade them together.
+The examples below are SDK reference material, not a fresh verification report
+for every snippet or older release. Use this repository's package manifests and
+lockfile for its tested Channels/runtime pair, and run the checks in
+`apps/channel/README.md` after changes. The [current Slack docs](https://docs.copilotkit.ai/slack)
+and installed setup skill supply current onboarding guidance. Channels and
+Runtime ship as a pair — review upgrades together.
 
 ## The mental model (five pieces)
 
@@ -166,7 +165,7 @@ avoid needing Intelligence — the runtime still owns the lifecycle.
 Do not reach for this because a managed Channel reports `setup_required` or
 because the dashboard is unfamiliar. Swapping to a direct adapter to "make it
 work" is a known failure mode, not a fallback. Fix the managed setup instead —
-see the `setup-slack-channel` skill.
+see the `channels-setup` skill installed by `npm run channel:setup -- --no-clipboard`.
 
 ```ts
 import { slack, defaultSlackTools, defaultSlackContext } from "@copilotkit/channels/slack";
@@ -292,7 +291,7 @@ node --env-file=.env --import tsx channel.ts
 per-Channel map. These are **not** the same vocabulary as the Intelligence
 dashboard's states (Disabled, Setup incomplete, Setup failed, Waiting for
 runtime, Conflict, Offline, Delivery failing, Online); for what each dashboard
-state means and how to clear it, see the `setup-slack-channel` skill.
+state means and how to clear it, see the installed `channels-setup` skill.
 
 | `status().overall` | What it means |
 | --- | --- |
@@ -627,7 +626,9 @@ task is specifically "add support for platform X".
 
 Creating the Slack app, storing its credentials, creating the managed Channel,
 and lining it up with a local runtime is a setup workflow rather than an API
-question. Use the **`setup-slack-channel`** skill for that, and for diagnosing a
+question. Run `npm run channel:setup -- --no-clipboard` from the repository root
+and follow the emitted prompt using the installed **`channels-setup`** skill.
+Choose Slack and reuse `apps/channel`. Use that skill also for diagnosing a
 Channel stuck at `setup_required`, sitting at Waiting for runtime, or Online but
 silent.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ Read [hackathon-overview.md](hackathon-overview.md), [hackathon-rules.md](hackat
 
 CopilotKit powers the Slack and web templates. The mobile starting point in `apps/mobile` has its own install and environment; follow its README for setup and checks.
 
+For setup, follow [CopilotKit onboarding](README.md#copilotkit-onboarding) after choosing an app. For Slack, run `npm run channel:setup -- --no-clipboard` and continue with the emitted prompt and installed `channels-setup` skill. For web/mobile, explain the model-only and Intelligence options before starting the official `onboard start` workflow. Preserve the chosen app and its working behavior; do not scaffold over this checkout or provision every template. Use current CLI instructions instead of copying authentication and provisioning steps from memory.
+
 Read `.agents/skills/build-channels-agent/SKILL.md` before touching anything in
 `apps/channel/`. It carries the verified API surface; the most common
 failure mode in this codebase is inventing a plausible-looking Channels API.

--- a/README.md
+++ b/README.md
@@ -38,12 +38,41 @@ Paste this into your coding agent:
 ```text
 Read AGENTS.md, hackathon-overview.md, hackathon-rules.md, and
 using-sponsor-tools.md. Help me choose one template app README for my idea,
-then build a new project using its infrastructure. Ask me who it is for and
-what the agent should do in that setting. Read the selected template before
-editing; for Slack also read .agents/skills/build-channels-agent/SKILL.md.
+then adapt this checkout into our own project. Ask me who it is for and
+what the agent should do in that setting. Follow this README's CopilotKit
+onboarding section for the selected app; keep its existing infrastructure.
 Use only the integrations the idea needs. Verify a complete interaction and
 prepare SUBMISSION.md, distinguishing inherited code from our event work.
 ```
+
+### CopilotKit onboarding
+
+Use the team's maintained setup prompts in the same coding-agent session, with this checkout as the project root. Choose one app first; setup should adapt that app rather than scaffold a second starter over it.
+
+| Your starting point | Onboarding path |
+|---|---|
+| Slack template | Run `npm run channel:setup -- --no-clipboard`, then have your agent follow the prompt it prints. This installs the current `channels-setup` skill; the command itself does not create a Channel or sign you in. Tell the agent to connect **Slack** using `apps/channel` and read its bundled `build-channels-agent` skill. |
+| Web or React Native template | The existing model-provider setup runs without Intelligence. To add managed conversations with Rich Threads and other Intelligence capabilities, use the prompt below for the chosen app. |
+
+**Connect the selected app to CopilotKit Intelligence:**
+
+```text
+Read AGENTS.md and the selected app README. Connect that app to CopilotKit
+Intelligence using the current official onboarding workflow. This checkout
+already has CopilotKit: preserve the existing app, agent, model provider,
+tools, and approval behavior. For apps/mobile, keep Expo and the separate
+mobile install; its runtime is served by apps/web.
+Generate a fresh 12-character hexadecimal run ID, substitute it for RUN_ID,
+then run from the repository root:
+npx --yes copilotkit@latest onboard start --run RUN_ID
+Follow the instructions returned by the CLI and reuse that ID for this run.
+Show the integration plan before editing, and prove the selected app works
+before and after connecting Intelligence.
+```
+
+The [official CopilotKit prompt](https://docs.copilotkit.ai/llms.txt) serves new projects, existing apps, and existing CopilotKit integrations. The [docs home](https://docs.copilotkit.ai/) also offers **Copy Prompt**, **Open in Codex**, and **Open in Claude Code**; add the selected template's context when using those entry points. For Slack, use the [Channels onboarding path](https://docs.copilotkit.ai/slack) above. Finish one selected workflow before starting another.
+
+Follow the CLI's returned instructions for sign-in, project selection, credentials, and verification. Keep credentials out of chat and preserve existing `.env` values. The starter reads `INTELLIGENCE_API_KEY`; if setup provisions `CPK_INTELLIGENCE_API_KEY`, map it to the variable the selected runtime actually reads. Review any required package upgrades together with the tested Channels/runtime pair and `@ag-ui/client` override. Intelligence onboarding changes the app; installing a skill or adding an API key alone does not complete that integration.
 
 ## Templates
 

--- a/apps/channel/README.md
+++ b/apps/channel/README.md
@@ -22,7 +22,13 @@ EXA_API_KEY=your-key
 EXA_SEARCH_TYPE=fast
 ```
 
-Choose an OpenAI model available to your account. Create the managed Channel using `npm run channel:setup`; the [setup guide](../../dev-docs/setup.md) and [screenshot walkthrough](../../dev-docs/channels-sdk-walkthrough/README.md) cover the Slack installation.
+Choose an OpenAI model available to your account. Start the official onboarding handoff:
+
+```bash
+npm run channel:setup -- --no-clipboard
+```
+
+This installs the maintained `channels-setup` skill and prints a prompt. Give that prompt to your coding agent in this checkout and specify **Slack**, using the existing `apps/channel` app. Have the agent follow the skill through sign-in, project/Channel configuration, Slack installation, and a real reply. The command alone does not create the Channel. Keep existing `.env` values; the listener reads `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`. The [shared onboarding notes](../../README.md#copilotkit-onboarding) explain CLI credential naming; the [setup guide](../../dev-docs/setup.md) and [screenshot walkthrough](../../dev-docs/channels-sdk-walkthrough/README.md) provide manual reference.
 
 ```bash
 npm run dev:slack
@@ -57,6 +63,9 @@ OpenRouter can be used as the model gateway through the shared provider settings
 ```text
 Read the root hackathon overview, rules, sponsor guide, and AGENTS.md.
 Read .agents/skills/build-channels-agent/SKILL.md before changing Slack code.
+If Slack is not connected, run npm run channel:setup -- --no-clipboard
+from the repository root and follow its prompt using the channels-setup
+skill. Select Slack and connect the existing apps/channel app.
 Adapt apps/channel to our project's user and conversation. Preserve
 read_thread, use Exa when research helps, and render results with Channels JSX.
 Replace incident-specific schemas, tools, and prompts with our own workflow.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -108,9 +108,14 @@ Good mobile fits include field checklists, travel plans, patient intake preparat
 
 ## Give this to your coding agent
 
+The existing Expo template runs with the configured model provider. To connect its conversations to Intelligence, use the [official onboarding prompt](../../README.md#copilotkit-onboarding) for `apps/mobile`, including its runtime in `apps/web`. Preserve the separate mobile install and device networking; onboarding must verify the native app, not just the web template. Managed conversations do not make the sample finance data persistent.
+
 ```text
 Read the root hackathon overview, rules, sponsor guide, AGENTS.md, and
-apps/mobile/README.md. Adapt apps/mobile to our mobile workflow. Keep
+apps/mobile/README.md. Explain the model-only and Intelligence options in
+README.md's CopilotKit onboarding section. If I choose Intelligence, follow
+its official prompt for the existing Expo app and its apps/web runtime.
+Adapt apps/mobile to our mobile workflow. Keep
 CopilotKit React Native headless APIs for app context, native tool rendering,
 and human-in-the-loop approval. Keep the runtime URL/device networking notes.
 Replace sample finance state and tools with our own app state and one complete

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -21,6 +21,8 @@ AMBIGUOUS_API_KEY=your-workspace-key
 
 Choose an OpenAI model your account can use. Use a demo workspace you control for the first write. This web template needs no managed Channel or Intelligence account.
 
+To add managed conversation persistence, use the [official Intelligence onboarding prompt](../../README.md#copilotkit-onboarding) with `apps/web` as the selected app. It connects this existing Next.js/CopilotKit app; keep the Ambiguous record workflow and page approval. Saving a task in Ambiguous and persisting a conversation in Intelligence are separate capabilities.
+
 To use OpenRouter, follow the [shared provider settings](../../using-sponsor-tools.md#openrouter): set `MODEL_PROVIDER=openrouter`, `OPENROUTER_API_KEY`, and a `MODEL` slug with tool support. Keep the Ambiguous workspace key; an OpenAI key is not required for OpenRouter chat.
 
 ```bash
@@ -57,6 +59,9 @@ The web chat does not receive raw Ambiguous write tools. It can propose a task a
 
 ```text
 Read the root hackathon overview, rules, sponsor guide, and AGENTS.md.
+Explain the model-only and Intelligence options in README.md's CopilotKit
+onboarding section. If I choose Intelligence, follow its official onboarding
+prompt for apps/web before customizing; preserve this existing integration.
 Adapt apps/web to our user and workflow. Keep CopilotKit React for page context,
 frontend tools, agent-rendered UI, and page approval. Use Ambiguous AI for
 persistent records. Do not expose raw write tools to the web chat when the page

--- a/dev-docs/channels-sdk-walkthrough/README.md
+++ b/dev-docs/channels-sdk-walkthrough/README.md
@@ -6,6 +6,8 @@ Take this starter from account sign-in to an agent that reads a Slack thread, re
 
 The screenshots come from a real run on September 10, 2026. We used an existing account, created a new project, and tested a synthetic incident. Credential entry is intentionally not pictured. Slack images are crops of the actual thread, with unrelated workspace navigation excluded.
 
+**Prefer agent-assisted setup?** Start with [the current Channels onboarding prompt](../../README.md#copilotkit-onboarding). It installs the maintained setup skill; give the emitted prompt to your agent and select Slack with the existing `apps/channel` app. Use this captured walkthrough as a manual reference when a dashboard step needs illustration.
+
 ## Before you start
 
 You need Node.js 22+, a CopilotKit Intelligence account, permission to install an app in your Slack workspace, and API access to one supported model provider. An existing API key works; a ChatGPT browser session alone does not configure this starter's model access.

--- a/dev-docs/setup.md
+++ b/dev-docs/setup.md
@@ -38,10 +38,12 @@ npm run dev:web
 Intelligence manages platform credentials and delivers over an outbound socket. Your listener stays running; no public tunnel is needed.
 
 ```bash
-npm run channel:setup
+npm run channel:setup -- --no-clipboard
 ```
 
-Follow the setup instructions it prints. Alternatively, create the Channel **before** the Slack app so the wizard can generate the correct manifest:
+This installs the current `channels-setup` skill and prints the official prompt. Continue with that prompt in your coding agent, selecting **Slack** and the existing `apps/channel` app. Let the agent follow the skill through setup and verify a real Slack reply. The command itself does not authenticate or provision the Channel. See [CopilotKit onboarding](../README.md#copilotkit-onboarding) for this handoff and the web/mobile Intelligence path.
+
+For manual setup, create the Channel **before** the Slack app so the wizard can generate the correct manifest:
 
 ```bash
 npx copilotkit@latest channels add --name my-agent \

--- a/using-sponsor-tools.md
+++ b/using-sponsor-tools.md
@@ -56,7 +56,7 @@ JS
 
 ## CopilotKit
 
-**Access and authentication.** The React web and React Native templates need only your model-provider account. The Slack template additionally uses [CopilotKit Intelligence](https://intelligence.copilotkit.ai/) to manage the Channel and Slack installation. Create a Channel with `npm run channel:setup`; follow [setup](dev-docs/setup.md) or the [illustrated walkthrough](dev-docs/channels-sdk-walkthrough/README.md).
+**Access and authentication.** The React web and React Native templates need only your model-provider account for CopilotKit's existing integration. To connect either app to Intelligence, use the [official onboarding prompt](README.md#copilotkit-onboarding). The Slack template additionally uses [CopilotKit Intelligence](https://intelligence.copilotkit.ai/) to manage the Channel and Slack installation. Run `npm run channel:setup -- --no-clipboard`, then give the emitted prompt to your coding agent and select Slack with the existing `apps/channel` app. This installs the maintained setup skill; the agent follows it to configure the Channel. Use [setup](dev-docs/setup.md) or the [illustrated walkthrough](dev-docs/channels-sdk-walkthrough/README.md) as manual references.
 
 **Configure Slack** in root `.env`, alongside the model settings:
 


### PR DESCRIPTION
The starter’s custom handoffs now use the team-maintained onboarding workflows. Slack setup explains how to run the CLI and continue with its installed `channels-setup` skill. Web and React Native expose the canonical Intelligence onboarding prompt while keeping the existing model-only setup available.

The prompts preserve the selected app, agent, model provider, Expo layout, and approval behavior. Common setup instructions and skill references match these paths. The bundled Channels guide also removes unsupported historical verification claims and scopes its hosting requirements to this managed starter.

Validation:
- 105 tests, all four package typechecks, the web production build, and iOS/Android exports passed on the unchanged runtime/dependency tree.
- Modified Markdown links and anchors, external onboarding sources, and diff hygiene passed; independent review completed.
- Published CLI 4.9.60 installed the current Channels skill and emitted its prompt. The live Channels guide matched the expected title and five phases; the general onboarding entry returned its prompt and fresh run ID.
- Incorporated the latest organizer and resource-link updates from main and rechecked the combined documentation.

Ten Markdown files changed. Application code, API examples, manifests, and lockfiles are unchanged. CLI smoke checks cover prompt retrieval and skill installation; authenticated Intelligence provisioning and live Slack delivery were not run.
