### PR TITLE
docs: use the supplied onboarding prompt verbatim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Read [hackathon-overview.md](hackathon-overview.md), [hackathon-rules.md](hackat
 
 CopilotKit powers the Slack and web templates. The mobile starting point in `apps/mobile` has its own install and environment; follow its README for setup and checks.
 
-For setup, follow [CopilotKit onboarding](README.md#copilotkit-onboarding) after choosing an app. For Slack, run `npm run channel:setup -- --no-clipboard` and continue with the emitted prompt and installed `channels-setup` skill. For web/mobile, explain the model-only and Intelligence options before starting the official `onboard start` workflow. Preserve the chosen app and its working behavior; do not scaffold over this checkout or provision every template. Use current CLI instructions instead of copying authentication and provisioning steps from memory.
+For setup, follow [CopilotKit onboarding](README.md#copilotkit-onboarding) after choosing an app. For Slack, run `npm run channel:setup -- --no-clipboard` and continue with the emitted prompt and installed `channels-setup` skill. For web, explain the model-only and Intelligence options before starting the official `onboard start` workflow. For mobile, follow the Expo setup instructions in `apps/mobile/README.md`, including its runtime in `apps/web`. Preserve the chosen app and its working behavior; do not scaffold over this checkout or provision every template. Use current CLI instructions instead of copying authentication and provisioning steps from memory.
 
 Read `.agents/skills/build-channels-agent/SKILL.md` before touching anything in
 `apps/channel/`. It carries the verified API surface; the most common

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Read [hackathon-overview.md](hackathon-overview.md), [hackathon-rules.md](hackat
 
 CopilotKit powers the Slack and web templates. The mobile starting point in `apps/mobile` has its own install and environment; follow its README for setup and checks.
 
-For setup, follow [CopilotKit onboarding](README.md#copilotkit-onboarding) after choosing an app. For Slack, run `npm run channel:setup -- --no-clipboard` and continue with the emitted prompt and installed `channels-setup` skill. For web, explain the model-only and Intelligence options before starting the official `onboard start` workflow. For mobile, follow the Expo setup instructions in `apps/mobile/README.md`, including its runtime in `apps/web`. Preserve the chosen app and its working behavior; do not scaffold over this checkout or provision every template. Use current CLI instructions instead of copying authentication and provisioning steps from memory.
+For web onboarding, use the [official prompt](README.md#copilotkit-onboarding) as written. For Slack, follow [Channels setup](apps/channel/README.md#get-started). For mobile, follow the [Expo setup instructions](apps/mobile/README.md#get-started).
 
 Read `.agents/skills/build-channels-agent/SKILL.md` before touching anything in
 `apps/channel/`. It carries the verified API surface; the most common

--- a/README.md
+++ b/README.md
@@ -50,25 +50,20 @@ Use the team's maintained setup prompts in the same coding-agent session, with t
 | Your starting point | Onboarding path |
 |---|---|
 | Slack template | Run `npm run channel:setup -- --no-clipboard`, then have your agent follow the prompt it prints. This installs the current `channels-setup` skill; the command itself does not create a Channel or sign you in. Tell the agent to connect **Slack** using `apps/channel` and read its bundled `build-channels-agent` skill. |
-| Web or React Native template | The existing model-provider setup runs without Intelligence. To add managed conversations with Rich Threads and other Intelligence capabilities, use the prompt below for the chosen app. |
+| Web template | The existing model-provider setup runs without Intelligence. To add managed conversations with Rich Threads and other Intelligence capabilities, use the prompt below for `apps/web`. |
+| React Native template | Follow the [Expo setup instructions](apps/mobile/README.md#get-started), including its runtime in `apps/web`. |
 
-**Connect the selected app to CopilotKit Intelligence:**
+**CopilotKit onboarding prompt for web:**
 
 ```text
-Read AGENTS.md and the selected app README. Connect that app to CopilotKit
-Intelligence using the current official onboarding workflow. This checkout
-already has CopilotKit: preserve the existing app, agent, model provider,
-tools, and approval behavior. For apps/mobile, keep Expo and the separate
-mobile install; its runtime is served by apps/web.
-Generate a fresh 12-character hexadecimal run ID, substitute it for RUN_ID,
-then run from the repository root:
-npx --yes copilotkit@latest onboard start --run RUN_ID
-Follow the instructions returned by the CLI and reuse that ID for this run.
-Show the integration plan before editing, and prove the selected app works
-before and after connecting Intelligence.
+Help me get started with CopilotKit. Run this command and follow the instructions:
+
+npx --yes copilotkit@latest onboard start
 ```
 
-The [official CopilotKit prompt](https://docs.copilotkit.ai/llms.txt) serves new projects, existing apps, and existing CopilotKit integrations. The [docs home](https://docs.copilotkit.ai/) also offers **Copy Prompt**, **Open in Codex**, and **Open in Claude Code**; add the selected template's context when using those entry points. For Slack, use the [Channels onboarding path](https://docs.copilotkit.ai/slack) above. Finish one selected workflow before starting another.
+For this starter, tell your agent that `apps/web` already has CopilotKit and ask it to preserve the existing app, agent, model provider, tools, and approval behavior. Have it read `AGENTS.md` and the app README, show the integration plan before editing, and verify the app before and after onboarding.
+
+The [docs home](https://docs.copilotkit.ai/) also offers **Copy Prompt**, **Open in Codex**, and **Open in Claude Code**. Use the web prompt above for `apps/web` and the [Channels onboarding path](https://docs.copilotkit.ai/slack) for Slack. Finish one selected workflow before starting another.
 
 Follow the CLI's returned instructions for sign-in, project selection, credentials, and verification. Keep credentials out of chat and preserve existing `.env` values. The starter reads `INTELLIGENCE_API_KEY`; if setup provisions `CPK_INTELLIGENCE_API_KEY`, map it to the variable the selected runtime actually reads. Review any required package upgrades together with the tested Channels/runtime pair and `@ag-ui/client` override. Intelligence onboarding changes the app; installing a skill or adding an API key alone does not complete that integration.
 

--- a/README.md
+++ b/README.md
@@ -45,15 +45,7 @@ prepare SUBMISSION.md, distinguishing inherited code from our event work.
 
 ### CopilotKit onboarding
 
-Use the team's maintained setup prompts in the same coding-agent session, with this checkout as the project root. Choose one app first; setup should adapt that app rather than scaffold a second starter over it.
-
-| Your starting point | Onboarding path |
-|---|---|
-| Slack template | Run `npm run channel:setup -- --no-clipboard`, then have your agent follow the prompt it prints. This installs the current `channels-setup` skill; the command itself does not create a Channel or sign you in. Tell the agent to connect **Slack** using `apps/channel` and read its bundled `build-channels-agent` skill. |
-| Web template | The existing model-provider setup runs without Intelligence. To add managed conversations with Rich Threads and other Intelligence capabilities, use the prompt below for `apps/web`. |
-| React Native template | Follow the [Expo setup instructions](apps/mobile/README.md#get-started), including its runtime in `apps/web`. |
-
-**CopilotKit onboarding prompt for web:**
+For web, paste this into your coding agent:
 
 ```text
 Help me get started with CopilotKit. Run this command and follow the instructions:
@@ -61,11 +53,7 @@ Help me get started with CopilotKit. Run this command and follow the instruction
 npx --yes copilotkit@latest onboard start
 ```
 
-For this starter, tell your agent that `apps/web` already has CopilotKit and ask it to preserve the existing app, agent, model provider, tools, and approval behavior. Have it read `AGENTS.md` and the app README, show the integration plan before editing, and verify the app before and after onboarding.
-
-The [docs home](https://docs.copilotkit.ai/) also offers **Copy Prompt**, **Open in Codex**, and **Open in Claude Code**. Use the web prompt above for `apps/web` and the [Channels onboarding path](https://docs.copilotkit.ai/slack) for Slack. Finish one selected workflow before starting another.
-
-Follow the CLI's returned instructions for sign-in, project selection, credentials, and verification. Keep credentials out of chat and preserve existing `.env` values. The starter reads `INTELLIGENCE_API_KEY`; if setup provisions `CPK_INTELLIGENCE_API_KEY`, map it to the variable the selected runtime actually reads. Review any required package upgrades together with the tested Channels/runtime pair and `@ag-ui/client` override. Intelligence onboarding changes the app; installing a skill or adding an API key alone does not complete that integration.
+For Slack, follow [Channels setup](apps/channel/README.md#get-started). For React Native, follow the [Expo setup instructions](apps/mobile/README.md#get-started).
 
 ## Templates
 

--- a/apps/channel/README.md
+++ b/apps/channel/README.md
@@ -28,7 +28,7 @@ Choose an OpenAI model available to your account. Start the official onboarding 
 npm run channel:setup -- --no-clipboard
 ```
 
-This installs the maintained `channels-setup` skill and prints a prompt. Give that prompt to your coding agent in this checkout and specify **Slack**, using the existing `apps/channel` app. Have the agent follow the skill through sign-in, project/Channel configuration, Slack installation, and a real reply. The command alone does not create the Channel. Keep existing `.env` values; the listener reads `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`. The [shared onboarding notes](../../README.md#copilotkit-onboarding) explain CLI credential naming; the [setup guide](../../dev-docs/setup.md) and [screenshot walkthrough](../../dev-docs/channels-sdk-walkthrough/README.md) provide manual reference.
+This installs the maintained `channels-setup` skill and prints a prompt. Give that prompt to your coding agent in this checkout and specify **Slack**, using the existing `apps/channel` app. Have the agent follow the skill through sign-in, project/Channel configuration, Slack installation, and a real reply. The command alone does not create the Channel. Keep existing `.env` values; the listener reads `CHANNEL_CODE` and `INTELLIGENCE_API_KEY`. The [setup guide](../../dev-docs/setup.md) and [screenshot walkthrough](../../dev-docs/channels-sdk-walkthrough/README.md) provide manual reference.
 
 ```bash
 npm run dev:slack

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -108,14 +108,12 @@ Good mobile fits include field checklists, travel plans, patient intake preparat
 
 ## Give this to your coding agent
 
-The existing Expo template runs with the configured model provider. To connect its conversations to Intelligence, use the [official onboarding prompt](../../README.md#copilotkit-onboarding) for `apps/mobile`, including its runtime in `apps/web`. Preserve the separate mobile install and device networking; onboarding must verify the native app, not just the web template. Managed conversations do not make the sample finance data persistent.
+The existing Expo template runs with the configured model provider. Follow [Get started](#get-started), including its runtime in `apps/web`. Preserve the separate mobile install and device networking, and verify the native app. The sample finance data is local and does not persist after restarting the app.
 
 ```text
 Read the root hackathon overview, rules, sponsor guide, AGENTS.md, and
-apps/mobile/README.md. Explain the model-only and Intelligence options in
-README.md's CopilotKit onboarding section. If I choose Intelligence, follow
-its official prompt for the existing Expo app and its apps/web runtime.
-Adapt apps/mobile to our mobile workflow. Keep
+apps/mobile/README.md. Follow the mobile setup instructions, including the
+runtime in apps/web. Adapt apps/mobile to our mobile workflow. Keep
 CopilotKit React Native headless APIs for app context, native tool rendering,
 and human-in-the-loop approval. Keep the runtime URL/device networking notes.
 Replace sample finance state and tools with our own app state and one complete

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -21,7 +21,7 @@ AMBIGUOUS_API_KEY=your-workspace-key
 
 Choose an OpenAI model your account can use. Use a demo workspace you control for the first write. This web template needs no managed Channel or Intelligence account.
 
-To add managed conversation persistence, use the [official CopilotKit onboarding prompt](../../README.md#copilotkit-onboarding) with `apps/web` as the selected app. Keep the starter-specific context outside the copied prompt: this app already has Next.js/CopilotKit, and its Ambiguous record workflow and page approval should be preserved. Saving a task in Ambiguous and persisting a conversation in Intelligence are separate capabilities.
+For CopilotKit onboarding, use the [official prompt](../../README.md#copilotkit-onboarding).
 
 To use OpenRouter, follow the [shared provider settings](../../using-sponsor-tools.md#openrouter): set `MODEL_PROVIDER=openrouter`, `OPENROUTER_API_KEY`, and a `MODEL` slug with tool support. Keep the Ambiguous workspace key; an OpenAI key is not required for OpenRouter chat.
 
@@ -59,9 +59,6 @@ The web chat does not receive raw Ambiguous write tools. It can propose a task a
 
 ```text
 Read the root hackathon overview, rules, sponsor guide, and AGENTS.md.
-Explain the model-only and Intelligence options in README.md's CopilotKit
-onboarding section. If I choose Intelligence, follow its official onboarding
-prompt for apps/web before customizing; preserve this existing integration.
 Adapt apps/web to our user and workflow. Keep CopilotKit React for page context,
 frontend tools, agent-rendered UI, and page approval. Use Ambiguous AI for
 persistent records. Do not expose raw write tools to the web chat when the page

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -21,7 +21,7 @@ AMBIGUOUS_API_KEY=your-workspace-key
 
 Choose an OpenAI model your account can use. Use a demo workspace you control for the first write. This web template needs no managed Channel or Intelligence account.
 
-To add managed conversation persistence, use the [official Intelligence onboarding prompt](../../README.md#copilotkit-onboarding) with `apps/web` as the selected app. It connects this existing Next.js/CopilotKit app; keep the Ambiguous record workflow and page approval. Saving a task in Ambiguous and persisting a conversation in Intelligence are separate capabilities.
+To add managed conversation persistence, use the [official CopilotKit onboarding prompt](../../README.md#copilotkit-onboarding) with `apps/web` as the selected app. Keep the starter-specific context outside the copied prompt: this app already has Next.js/CopilotKit, and its Ambiguous record workflow and page approval should be preserved. Saving a task in Ambiguous and persisting a conversation in Intelligence are separate capabilities.
 
 To use OpenRouter, follow the [shared provider settings](../../using-sponsor-tools.md#openrouter): set `MODEL_PROVIDER=openrouter`, `OPENROUTER_API_KEY`, and a `MODEL` slug with tool support. Keep the Ambiguous workspace key; an OpenAI key is not required for OpenRouter chat.
 

--- a/dev-docs/setup.md
+++ b/dev-docs/setup.md
@@ -41,7 +41,7 @@ Intelligence manages platform credentials and delivers over an outbound socket. 
 npm run channel:setup -- --no-clipboard
 ```
 
-This installs the current `channels-setup` skill and prints the official prompt. Continue with that prompt in your coding agent, selecting **Slack** and the existing `apps/channel` app. Let the agent follow the skill through setup and verify a real Slack reply. The command itself does not authenticate or provision the Channel. See [CopilotKit onboarding](../README.md#copilotkit-onboarding) for this handoff and the web/mobile Intelligence path.
+This installs the current `channels-setup` skill and prints the official prompt. Continue with that prompt in your coding agent, selecting **Slack** and the existing `apps/channel` app. Let the agent follow the skill through setup and verify a real Slack reply. The command itself does not authenticate or provision the Channel. See [CopilotKit onboarding](../README.md#copilotkit-onboarding) for this handoff and the web onboarding prompt; follow the [mobile README](../apps/mobile/README.md#get-started) for Expo setup.
 
 For manual setup, create the Channel **before** the Slack app so the wizard can generate the correct manifest:
 

--- a/using-sponsor-tools.md
+++ b/using-sponsor-tools.md
@@ -56,7 +56,7 @@ JS
 
 ## CopilotKit
 
-**Access and authentication.** The React web and React Native templates need only your model-provider account for CopilotKit's existing integration. To connect either app to Intelligence, use the [official onboarding prompt](README.md#copilotkit-onboarding). The Slack template additionally uses [CopilotKit Intelligence](https://intelligence.copilotkit.ai/) to manage the Channel and Slack installation. Run `npm run channel:setup -- --no-clipboard`, then give the emitted prompt to your coding agent and select Slack with the existing `apps/channel` app. This installs the maintained setup skill; the agent follows it to configure the Channel. Use [setup](dev-docs/setup.md) or the [illustrated walkthrough](dev-docs/channels-sdk-walkthrough/README.md) as manual references.
+**Access and authentication.** The React web and React Native templates need only your model-provider account for CopilotKit's existing integration. To connect the web app to Intelligence, use the [official onboarding prompt](README.md#copilotkit-onboarding). For React Native, follow the [Expo setup instructions](apps/mobile/README.md#get-started). The Slack template additionally uses [CopilotKit Intelligence](https://intelligence.copilotkit.ai/) to manage the Channel and Slack installation. Run `npm run channel:setup -- --no-clipboard`, then give the emitted prompt to your coding agent and select Slack with the existing `apps/channel` app. This installs the maintained setup skill; the agent follows it to configure the Channel. Use [setup](dev-docs/setup.md) or the [illustrated walkthrough](dev-docs/channels-sdk-walkthrough/README.md) as manual references.
 
 **Configure Slack** in root `.env`, alongside the model settings:
 


### PR DESCRIPTION
The README now uses the supplied onboarding prompt verbatim:

```text
Help me get started with CopilotKit. Run this command and follow the instructions:

npx --yes copilotkit@latest onboard start
```

Removes the manual run-ID step and the additional onboarding instructions. Related web handoffs point directly to the supplied prompt.

Slack retains its Channels setup path, and React Native links to the existing Expo setup instructions.

Validation:
- Exact copy/paste prompt checked; no manual run-ID step or added onboarding instructions remain around it.
- Root typecheck, relative links/anchors, and diff hygiene checked.
- Application code, dependencies, and configuration are unchanged; prior runtime test/build results remain applicable.

Seven Markdown files changed. Authenticated onboarding and live Slack delivery were not run.
